### PR TITLE
begin clearing errors and warning

### DIFF
--- a/atools.pro
+++ b/atools.pro
@@ -49,7 +49,7 @@
 # End of configuration documentation
 # =============================================================================
 
-QT += sql xml svg core widgets network
+QT += sql xml svg core widgets network core5compat
 QT -= gui
 CONFIG += build_all c++14 staticlib
 CONFIG -= debug_and_release debug_and_release_target

--- a/src/atools.cpp
+++ b/src/atools.cpp
@@ -67,7 +67,7 @@ QStringList probeFile(const QString& file, int numLinesRead)
   if(testFile.open(QIODevice::ReadOnly))
   {
     QTextStream stream(&testFile);
-    stream.setCodec("UTF-8");
+    stream.setEncoding(QStringConverter::Utf8);
     stream.setAutoDetectUnicode(true);
 
     int numLines = 0, numLinesTotal = 0;
@@ -435,7 +435,7 @@ QTime timeFromHourMinStr(const QString& timeStr)
   if(timeStr.contains(":"))
     time = QTime(timeStr.section(':', 0, 0).toInt(&okHours), timeStr.section(':', 1, 1).toInt(&okMinutes));
   else if(timeStr.length() == 3 || timeStr.length() == 4)
-    time = QTime(timeStr.left(timeStr.length() - 2).toInt(&okHours), timeStr.rightRef(2).toInt(&okMinutes));
+    time = QTime(timeStr.left(timeStr.length() - 2).toInt(&okHours), timeStr.right(2).toInt(&okMinutes));
 
   return !okHours || !okMinutes ? QTime() : time;
 }

--- a/src/atools.h
+++ b/src/atools.h
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QLineF>
 #include <QPointF>
+#include <QTextCodec>
 
 class QFile;
 class QFileInfo;
@@ -167,12 +168,6 @@ Q_DECL_CONSTEXPR bool inRange(const QList<TYPE>& list, int index)
 }
 
 template<typename TYPE>
-Q_DECL_CONSTEXPR bool inRange(const QVector<TYPE>& list, int index)
-{
-  return index >= 0 && index < list.size();
-}
-
-template<typename TYPE>
 Q_DECL_CONSTEXPR bool inRange(TYPE minValue, TYPE maxValue, TYPE index)
 {
   return index >= minValue && index <= maxValue;
@@ -213,27 +208,7 @@ const TYPE& at(const QList<TYPE>& list, int index, const TYPE& defaultType = TYP
 }
 
 template<typename TYPE>
-const TYPE& at(const QVector<TYPE>& list, int index, const TYPE& defaultType = TYPE())
-{
-  if(inRange(list, index))
-    return list.at(index);
-  else
-    qWarning() << "index out of bounds:" << index << "list size" << list.size();
-  return defaultType;
-}
-
-template<typename TYPE>
 const TYPE& at(const QList<TYPE>& list, int index, const QString& msg, const TYPE& defaultType = TYPE())
-{
-  if(inRange(list, index))
-    return list.at(index);
-  else
-    qWarning() << "index out of bounds:" << index << "list size" << list.size() << "message" << msg;
-  return defaultType;
-}
-
-template<typename TYPE>
-const TYPE& at(const QVector<TYPE>& list, int index, const QString& msg, const TYPE& defaultType = TYPE())
 {
   if(inRange(list, index))
     return list.at(index);
@@ -257,18 +232,6 @@ TYPE *firstOrNull(QList<TYPE>& list)
 
 template<typename TYPE>
 const TYPE *firstOrNull(const QList<TYPE>& list)
-{
-  return list.isEmpty() ? nullptr : &list.first();
-}
-
-template<typename TYPE>
-TYPE *firstOrNull(QVector<TYPE>& list)
-{
-  return list.isEmpty() ? nullptr : &list.first();
-}
-
-template<typename TYPE>
-const TYPE *firstOrNull(const QVector<TYPE>& list)
 {
   return list.isEmpty() ? nullptr : &list.first();
 }

--- a/src/fs/bgl/ap/airport.cpp
+++ b/src/fs/bgl/ap/airport.cpp
@@ -137,13 +137,13 @@ Airport::Airport(const NavDatabaseOptions *options, BinaryStream *bs,
     rec::AirportRecordType type = r.getId<rec::AirportRecordType>();
     if(checkSubRecord(r))
     {
-      qWarning().noquote().nospace() << Q_FUNC_INFO << "Invalid record" << hex << " 0x" << r.getId()
-                                     << dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
+      qWarning().noquote().nospace() << Q_FUNC_INFO << "Invalid record" << Qt::hex << " 0x" << r.getId()
+                                     << Qt::dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
       return;
     }
 
-    // qDebug().nospace() << Q_FUNC_INFO << hex << " 0x" << r.getId()
-    // << dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
+    // qDebug().nospace() << Q_FUNC_INFO << Qt::hex << " 0x" << r.getId()
+    // << Qt::dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
 
     switch(type)
     {
@@ -361,19 +361,19 @@ Airport::Airport(const NavDatabaseOptions *options, BinaryStream *bs,
       case rec::MSFS_SID:
       case rec::MSFS_STAR:
 
-        // qWarning() << Q_FUNC_INFO << "Unknown record" << hex << " 0x" << r.getId()
-        // << dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
+        // qWarning() << Q_FUNC_INFO << "Unknown record" << Qt::hex << " 0x" << r.getId()
+        // << Qt::dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
         break;
 
       default:
 
-        qWarning().noquote().nospace() << "Unknown record" << hex << " 0x" << r.getId()
-                                       << dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
+        qWarning().noquote().nospace() << "Unknown record" << Qt::hex << " 0x" << r.getId()
+                                       << Qt::dec << " " << airportRecordTypeStr(type) << " " << bs->tellg();
 
         if(subrecordIndex == 0)
         {
           qWarning().nospace().noquote() << "Ignoring airport. Unexpected initial record type in Airport record 0x"
-                                         << hex << type << dec << getObjectName();
+                                         << Qt::hex << type << Qt::dec << getObjectName();
 
           // Stop reading when the first subrecord is already invalid
           seekToStart();
@@ -667,14 +667,14 @@ void Airport::updateParking(const QList<atools::fs::bgl::Jetway>& jetways,
     if(index != -1 && index < parkings.size())
     {
       if(parkings.at(index).jetway)
-        qWarning().nospace().noquote() << "Parking for jetway " << jw << " already set" << dec
+        qWarning().nospace().noquote() << "Parking for jetway " << jw << " already set" << Qt::dec
                                        << " for parking " << parkings.at(index)
                                        << " for ident " << ident;
       else
         parkings[index].jetway = true;
     }
     else
-      qWarning().nospace().noquote() << "Parking for jetway " << jw << " not found" << dec
+      qWarning().nospace().noquote() << "Parking for jetway " << jw << " not found" << Qt::dec
                                      << " for ident " << ident;
   }
 }
@@ -777,7 +777,7 @@ QDebug operator<<(QDebug out, const Airport& record)
                           << ", name " << record.name
                           << ", region " << record.region
                           << ", " << record.position.getPos()
-                          << ", magvar " << record.magVar << ", " << endl;
+                          << ", magvar " << record.magVar << ", " << Qt::endl;
   out << record.runways;
   out << record.coms;
   out << record.aprons;

--- a/src/fs/bgl/ap/approach.cpp
+++ b/src/fs/bgl/ap/approach.cpp
@@ -123,7 +123,7 @@ Approach::Approach(const NavDatabaseOptions *options, BinaryStream *bs, bool sid
           break;
 
         default:
-          qWarning().nospace().noquote() << "Unexpected record type in approach record 0x" << hex << t << dec
+          qWarning().nospace().noquote() << "Unexpected record type in approach record 0x" << Qt::hex << t << Qt::dec
                                          << " for airport ident " << fixAirportIdent << bs->tellg();
       }
       r.seekToEnd();
@@ -145,7 +145,7 @@ QDebug operator<<(QDebug out, const Approach& record)
                           << ", fix region " << record.fixRegion
                           << ", ap icao " << record.fixAirportIdent
                           << ", alt " << record.altitude
-                          << ", hdg " << record.heading << endl;
+                          << ", hdg " << record.heading << Qt::endl;
   out << record.transitions;
   out << record.legs;
   out << record.missedLegs;

--- a/src/fs/bgl/ap/apron.cpp
+++ b/src/fs/bgl/ap/apron.cpp
@@ -60,7 +60,7 @@ QDebug operator<<(QDebug out, const Apron& record)
 
   out.nospace().noquote() << static_cast<const Record&>(record)
                           << " Runway[surface " << surface::surfaceToDbStr(record.surface) << "/"
-                          << surface::surfaceToDbStr(record.surface) << endl;
+                          << surface::surfaceToDbStr(record.surface) << Qt::endl;
   out << record.vertices;
   out << "]";
   return out;

--- a/src/fs/bgl/ap/apron2.cpp
+++ b/src/fs/bgl/ap/apron2.cpp
@@ -71,7 +71,7 @@ QDebug operator<<(QDebug out, const Apron2& record)
                           << " Apron2[surface " << surface::surfaceToDbStr(record.surface) << "/"
                           << surface::surfaceToDbStr(record.surface)
                           << ", drawSurface " << record.drawSurface
-                          << ", drawDetail " << record.drawDetail << endl;
+                          << ", drawDetail " << record.drawDetail << Qt::endl;
   out << record.vertices;
   out << record.triangles;
   out << "]";

--- a/src/fs/bgl/ap/del/deleteairport.cpp
+++ b/src/fs/bgl/ap/del/deleteairport.cpp
@@ -47,7 +47,7 @@ QString DeleteAirport::deleteAllFlagsToStr(del::DeleteAllFlags flags)
 
   // TODO find out missing flags with bgl compiler also for MSFS
   // else if(flags != 0)
-  // qWarning().nospace().noquote() << "Found unknown delete all flags 0x" << hex << flags;
+  // qWarning().nospace().noquote() << "Found unknown delete all flags 0x" << Qt::hex << flags;
 
   if(retval.endsWith(","))
     retval.chop(1);

--- a/src/fs/bgl/ap/helipad.cpp
+++ b/src/fs/bgl/ap/helipad.cpp
@@ -75,7 +75,7 @@ QDebug operator<<(QDebug out, const Helipad& record)
 
   out.nospace().noquote() << static_cast<const Record&>(record)
   << " Helipad[type " << Helipad::helipadTypeToStr(record.type)
-  << ", surface " << surface::surfaceToDbStr(record.surface) << endl
+  << ", surface " << surface::surfaceToDbStr(record.surface) << Qt::endl
   << ", length " << record.length
   << ", width " << record.width
   << ", heading " << record.heading

--- a/src/fs/bgl/ap/rw/runway.cpp
+++ b/src/fs/bgl/ap/rw/runway.cpp
@@ -234,7 +234,7 @@ Runway::Runway(const NavDatabaseOptions *options, BinaryStream *bs, const QStrin
         break;
 
       default:
-        qWarning().nospace().noquote() << "Unexpected record type in Runway record 0x" << hex << t << dec
+        qWarning().nospace().noquote() << "Unexpected record type in Runway record 0x" << Qt::hex << t << Qt::dec
                                        << " for ident " << airportIdent
                                        << " runway " << primary.getName() << "/" << secondary.getName()
                                        << " " << bs->tellg();
@@ -284,9 +284,9 @@ QDebug operator<<(QDebug out, const Runway& record)
                           << " Runway[length " << record.length
                           << ", width " << record.width
                           << ", hdg " << record.heading
-                          << ", surface " << surface::surfaceToDbStr(record.surface) << endl
-                          << ", primary " << record.primary << endl
-                          << ", secondary " << record.secondary << endl
+                          << ", surface " << surface::surfaceToDbStr(record.surface) << Qt::endl
+                          << ", primary " << record.primary << Qt::endl
+                          << ", secondary " << record.secondary << Qt::endl
                           << "]";
   return out;
 }

--- a/src/fs/bgl/ap/transition.cpp
+++ b/src/fs/bgl/ap/transition.cpp
@@ -128,7 +128,7 @@ Transition::Transition(const NavDatabaseOptions *options, BinaryStream *bs)
         break;
 
       default:
-        qWarning().nospace().noquote() << "Unexpected record type in transition record 0x" << hex << t << dec
+        qWarning().nospace().noquote() << "Unexpected record type in transition record 0x" << Qt::hex << t << Qt::dec
                                        << " for airport ident " << fixAirportIdent;
     }
     r.seekToEnd();
@@ -151,7 +151,7 @@ QDebug operator<<(QDebug out, const Transition& record)
                           << ", dmeRegion " << record.dmeRegion
                           << ", dmeAirportIdent " << record.dmeAirportIdent
                           << ", dmeRadial " << record.dmeRadial
-                          << ", dmeDist " << record.dmeDist << endl;
+                          << ", dmeDist " << record.dmeDist << Qt::endl;
   out << record.legs;
   out << "]";
   return out;

--- a/src/fs/bgl/bglbase.cpp
+++ b/src/fs/bgl/bglbase.cpp
@@ -54,7 +54,7 @@ void BglBase::seekToStart()
 QDebug operator<<(QDebug out, const BglBase& base)
 {
   QDebugStateSaver saver(out);
-  out.nospace().noquote() << hex << " BglBase[start 0x" << base.startOffset << "]";
+  out.nospace().noquote() << Qt::hex << " BglBase[start 0x" << base.startOffset << "]";
   return out;
 }
 

--- a/src/fs/bgl/bglfile.cpp
+++ b/src/fs/bgl/bglfile.cpp
@@ -166,7 +166,7 @@ void BglFile::handleBoundaries(BinaryStream *bs)
     else if(type != rec::GEOPOL)
       // Should only contain boundaries and geopol records
       qWarning().nospace() << "while reading boundaries: unexpected record "
-                           << hex << "0x" << type << " at " << hex << "0x" << bs->tellg();
+                           << Qt::hex << "0x" << type << " at " << Qt::hex << "0x" << bs->tellg();
 
     rec.seekToEnd();
   }
@@ -255,7 +255,7 @@ void BglFile::readRecords(BinaryStream *bs, const atools::fs::scenery::SceneryAr
     if(options->isVerbose())
     {
       qDebug() << "=======================";
-      qDebug().nospace().noquote() << "Records of 0x" << hex << subsection.getFirstDataRecordOffset() << dec
+      qDebug().nospace().noquote() << "Records of 0x" << Qt::hex << subsection.getFirstDataRecordOffset() << Qt::dec
                                    << " type " << sectionTypeStr(type);
     }
 
@@ -372,7 +372,7 @@ void BglFile::readRecords(BinaryStream *bs, const atools::fs::scenery::SceneryAr
           break;
 
         default:
-          qWarning().nospace().noquote() << "Unknown section type at 0x" << hex << bs->tellg() << dec << ": " << type;
+          qWarning().nospace().noquote() << "Unknown section type at 0x" << Qt::hex << bs->tellg() << Qt::dec << ": " << type;
 
       }
       if(rec == nullptr)
@@ -383,7 +383,7 @@ void BglFile::readRecords(BinaryStream *bs, const atools::fs::scenery::SceneryAr
         rec->seekToEnd();
       else
         qWarning().nospace().noquote() << "Invalid record size " << rec->getSize()
-                                       << " at 0x" << hex << bs->tellg()
+                                       << " at 0x" << Qt::hex << bs->tellg()
                                        << " type 0x" << rec->getId();
     }
   }

--- a/src/fs/bgl/boundary.cpp
+++ b/src/fs/bgl/boundary.cpp
@@ -140,7 +140,7 @@ Boundary::Boundary(const NavDatabaseOptions *options, BinaryStream *bs)
 {
   if(id != rec::BOUNDARY)
   {
-    qWarning() << "Not a boundary record" << hex << "0x" << id << dec;
+    qWarning() << "Not a boundary record" << Qt::hex << "0x" << id << Qt::dec;
     excluded = true;
     return;
   }
@@ -227,7 +227,7 @@ QDebug operator<<(QDebug out, const Boundary& record)
                           << ", minAltType " << Boundary::altTypeToStr(record.minAltType)
                           << ", maxAltType " << Boundary::altTypeToStr(record.maxAltType)
                           << ", minPosition " << record.minPosition
-                          << ", maxPosition " << record.maxPosition << endl;
+                          << ", maxPosition " << record.maxPosition << Qt::endl;
   out << record.lines;
   out << "]";
 

--- a/src/fs/bgl/converter.cpp
+++ b/src/fs/bgl/converter.cpp
@@ -74,9 +74,9 @@ QString intToIcao(unsigned int icao, bool noBitShift)
     if(coded == 0)
       break;
     if(coded > 1 && coded < 12)
-      icaoStr.insert(0, '0' + (coded - 2));
+      icaoStr.insert(0, "0" + QString((QChar)(coded - 2)));
     else
-      icaoStr.insert(0, 'A' + (coded - 12));
+      icaoStr.insert(0, "A" + QString((QChar)(coded - 12)));
   }
   return icaoStr;
 }
@@ -100,7 +100,7 @@ QString runwayToStr(int runwayNumber, int designator)
   {
     // Normal one digit runway number with leading zero
     retval += "0";
-    retval += static_cast<char>(runwayNumber) + '0';
+    retval += QString((QChar)((int)'0' + runwayNumber));
   }
   else if(runwayNumber > 36)
   {
@@ -138,8 +138,8 @@ QString runwayToStr(int runwayNumber, int designator)
   else
   {
     // Normal two digit runway number without leading zero
-    retval += static_cast<char>(runwayNumber / 10) + '0';
-    retval += static_cast<char>(runwayNumber % 10) + '0';
+    retval += QString((QChar)((int)'0' + (runwayNumber / 10)));
+    retval += QString((QChar)((int)'0' + (runwayNumber % 10)));
   }
   // Add designator if there is one
   retval += designatorStr(designator);

--- a/src/fs/bgl/header.cpp
+++ b/src/fs/bgl/header.cpp
@@ -38,7 +38,7 @@ Header::Header(const atools::fs::NavDatabaseOptions *options, BinaryStream *bs)
   headerSize = bs->readUInt();
   if(headerSize != HEADER_SIZE)
   {
-    qWarning().nospace().noquote() << "Invalid header size: 0x" << hex << headerSize << dec;
+    qWarning().nospace().noquote() << "Invalid header size: 0x" << Qt::hex << headerSize << Qt::dec;
     // Disabled for www.fsaerodata.com
     // validSize = false;
   }
@@ -51,11 +51,11 @@ Header::Header(const atools::fs::NavDatabaseOptions *options, BinaryStream *bs)
     validMagicNumber = false;
 
   if(!validMagicNumber)
-    qWarning().nospace().noquote() << "Invalid magic number: 0x" << hex << magicNumber1
-                                   << ", 0x" << magicNumber2 << dec;
+    qWarning().nospace().noquote() << "Invalid magic number: 0x" << Qt::hex << magicNumber1
+                                   << ", 0x" << magicNumber2 << Qt::dec;
 
   // if(!validSize)
-  // qWarning().nospace().noquote() << "Invalid header size: 0x" << hex << headerSize << dec;
+  // qWarning().nospace().noquote() << "Invalid header size: 0x" << Qt::hex << headerSize << Qt::dec;
 
   if(!validMagicNumber || !validSize)
     // Stop reading here if anything is wrong
@@ -76,9 +76,7 @@ Header::~Header()
 
 QString Header::getCreationTimestampString() const
 {
-  QDateTime dt;
-  dt.setTime_t(static_cast<uint>(creationTimestamp));
-  return dt.toString(Qt::ISODate);
+  return QDateTime::fromSecsSinceEpoch(creationTimestamp).toString(Qt::ISODate);
 }
 
 QDebug operator<<(QDebug out, const Header& header)
@@ -86,12 +84,12 @@ QDebug operator<<(QDebug out, const Header& header)
   QDebugStateSaver saver(out);
 
   out.nospace().noquote() << static_cast<const BglBase&>(header)
-                          << hex << " Header[magic number 1 0x" << header.magicNumber1 << dec
+                          << Qt::hex << " Header[magic number 1 0x" << header.magicNumber1 << Qt::dec
                           << ", size " << header.headerSize
-                          << hex << ", low timestamp 0x" << header.lowDateTime
-                          << ", high timestamp 0x" << header.highDateTime << dec
+                          << Qt::hex << ", low timestamp 0x" << header.lowDateTime
+                          << ", high timestamp 0x" << header.highDateTime << Qt::dec
                           << ", timestamp " << header.getCreationTimestampString()
-                          << hex << ", magic number 2 0x" << header.magicNumber2 << dec
+                          << Qt::hex << ", magic number 2 0x" << header.magicNumber2 << Qt::dec
                           << ", sections " << header.numSections
                           << "]";
   return out;

--- a/src/fs/bgl/nav/ils.cpp
+++ b/src/fs/bgl/nav/ils.cpp
@@ -99,7 +99,7 @@ Ils::Ils(const NavDatabaseOptions *options, BinaryStream *bs)
         break;
       default:
         qWarning().nospace().noquote() << "Unexpected record type in ILS record 0x"
-                                       << hex << t << dec << " for ident " << ident;
+                                       << Qt::hex << t << Qt::dec << " for ident " << ident;
     }
     r.seekToEnd();
   }

--- a/src/fs/bgl/nav/ndb.cpp
+++ b/src/fs/bgl/nav/ndb.cpp
@@ -81,7 +81,7 @@ Ndb::Ndb(const NavDatabaseOptions *options, BinaryStream *bs)
         break;
       default:
         qWarning().nospace().noquote() << "Unexpected record type in NDB record 0x"
-                                       << hex << t << dec << " for ident " << ident;
+                                       << Qt::hex << t << Qt::dec << " for ident " << ident;
     }
     r.seekToEnd();
   }

--- a/src/fs/bgl/nav/tacan.cpp
+++ b/src/fs/bgl/nav/tacan.cpp
@@ -70,7 +70,7 @@ Tacan::Tacan(const NavDatabaseOptions *options, BinaryStream *bs)
       case rec::GLIDESLOPE:
         break;
       default:
-        qWarning().nospace().noquote() << "Unexpected record type in TACAN record 0x" << hex << t << dec <<
+        qWarning().nospace().noquote() << "Unexpected record type in TACAN record 0x" << Qt::hex << t << Qt::dec <<
           " for ident " << ident;
     }
     r.seekToEnd();

--- a/src/fs/bgl/nav/vor.cpp
+++ b/src/fs/bgl/nav/vor.cpp
@@ -92,7 +92,7 @@ Vor::Vor(const NavDatabaseOptions *options, BinaryStream *bs)
       case atools::fs::bgl::rec::GLIDESLOPE:
         break;
         // default:
-        // qWarning().nospace().noquote() << "Unexpected record type in VOR record 0x" << hex << t << dec <<
+        // qWarning().nospace().noquote() << "Unexpected record type in VOR record 0x" << Qt::hex << t << Qt::dec <<
         // " for ident " << ident;
     }
     r.seekToEnd();

--- a/src/fs/bgl/nav/waypoint.cpp
+++ b/src/fs/bgl/nav/waypoint.cpp
@@ -138,7 +138,7 @@ QDebug operator<<(QDebug out, const Waypoint& record)
                           << ", magVar " << record.magVar
                           << ", ident " << record.ident
                           << ", region " << record.region
-                          << ", airport ID " << record.airportIdent << endl;
+                          << ", airport ID " << record.airportIdent << Qt::endl;
   out << record.airways;
   out << "]";
   return out;

--- a/src/fs/bgl/nl/namelist.cpp
+++ b/src/fs/bgl/nl/namelist.cpp
@@ -110,7 +110,7 @@ QDebug operator<<(QDebug out, const Namelist& record)
   QDebugStateSaver saver(out);
 
   out.nospace().noquote() << static_cast<const Record&>(record)
-                          << "Namelist[numIcaoIdent " << record.entries.size() << endl;
+                          << "Namelist[numIcaoIdent " << record.entries.size() << Qt::endl;
   out << record.entries;
   out << "]";
 

--- a/src/fs/bgl/record.cpp
+++ b/src/fs/bgl/record.cpp
@@ -55,7 +55,7 @@ bool Record::checkSubRecord(const Record& r)
   if(r.getSize() == 0)
   {
     qWarning().nospace().noquote() << "Ignoring airport. Size of record is zero. 0x"
-                                   << hex << r.getId<int>() << dec << getObjectName();
+                                   << Qt::hex << r.getId<int>() << Qt::dec << getObjectName();
 
     // Stop reading when the first subrecord is already invalid
     seekToStart();
@@ -70,7 +70,7 @@ QDebug operator<<(QDebug out, const Record& record)
   QDebugStateSaver saver(out);
 
   out.nospace().noquote() << static_cast<const BglBase&>(record)
-                          << hex << " Record[id 0x" << record.id << dec
+                          << Qt::hex << " Record[id 0x" << record.id << Qt::dec
                           << ", size " << record.size << "]";
   return out;
 }

--- a/src/fs/bgl/section.cpp
+++ b/src/fs/bgl/section.cpp
@@ -49,7 +49,7 @@ QDebug operator<<(QDebug out, const Section& section)
   << " Section[type " << sectionTypeStr(section.type)
   << ", size " << section.subsectionSize
   << ", subsections " << section.numSubsections
-  << hex << ", offset 0x" << section.firstSubsectionOffset << dec
+  << Qt::hex << ", offset 0x" << section.firstSubsectionOffset << Qt::dec
   << ", total size " << section.totalSubsectionSize << "]";
   return out;
 }

--- a/src/fs/bgl/subsection.cpp
+++ b/src/fs/bgl/subsection.cpp
@@ -46,9 +46,9 @@ QDebug operator<<(QDebug out, const Subsection& section)
 
   out.nospace().noquote() << static_cast<const BglBase&>(section)
   << " Subsection[parent type " << sectionTypeStr(section.getParent().getType())
-  << hex << ", id 0x" << section.id << dec
+  << Qt::hex << ", id 0x" << section.id << Qt::dec
   << ", records " << section.numDataRecords
-  << hex << ", offset 0x" << section.firstDataRecordOffset << dec
+  << Qt::hex << ", offset 0x" << section.firstDataRecordOffset << Qt::dec
   << ", size " << section.dataSize << "]";
   return out;
 }

--- a/src/fs/common/binarygeometry.cpp
+++ b/src/fs/common/binarygeometry.cpp
@@ -18,6 +18,7 @@
 #include "fs/common/binarygeometry.h"
 
 #include <QDataStream>
+#include <QIODevice>
 
 namespace atools {
 namespace fs {

--- a/src/fs/common/metadatawriter.cpp
+++ b/src/fs/common/metadatawriter.cpp
@@ -43,9 +43,9 @@ void MetadataWriter::writeFile(const QString& filepath, const QString& comment, 
   QFileInfo fileinfo(filepath);
 
   insertFileQuery->bindValue(":bgl_file_id", curFileId);
-  insertFileQuery->bindValue(":file_modification_time", fileinfo.lastModified().toTime_t());
+  insertFileQuery->bindValue(":file_modification_time", fileinfo.lastModified().toSecsSinceEpoch());
   insertFileQuery->bindValue(":scenery_area_id", curSceneryId);
-  insertFileQuery->bindValue(":bgl_create_time", fileinfo.lastModified().toTime_t());
+  insertFileQuery->bindValue(":bgl_create_time", fileinfo.lastModified().toSecsSinceEpoch());
   insertFileQuery->bindValue(":filepath", fileinfo.filePath());
   insertFileQuery->bindValue(":filename", fileinfo.fileName());
   insertFileQuery->bindValue(":size", fileinfo.size());

--- a/src/fs/common/morareader.cpp
+++ b/src/fs/common/morareader.cpp
@@ -23,6 +23,7 @@
 #include "exception.h"
 
 #include <QDataStream>
+#include <QIODevice>
 
 using atools::sql::SqlQuery;
 using atools::sql::SqlUtil;

--- a/src/fs/common/procedurewriter.cpp
+++ b/src/fs/common/procedurewriter.cpp
@@ -27,7 +27,9 @@
 
 #include "sql/sqlutil.h"
 
+#if ! _MSC_VER || __INTEL_COMPILER                      // intel compiler defines _MSC_VER, didn't check whether it supports GCC
 #pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
 
 using atools::sql::SqlQuery;
 using atools::sql::SqlUtil;
@@ -647,7 +649,7 @@ void ProcedureWriter::writeApproachLeg(const ProcedureInput& line)
 
   if(waypointDescr.size() > 3)
   {
-    if(waypointDescr.at(3) == "F" && curRowCode == rc::APPROACH)
+    if(waypointDescr.at(3) == 'F' && curRowCode == rc::APPROACH)
     {
       NavIdInfo fafInfo = navaidTypeFix(line);
       // FAF - use this one to set the approach name
@@ -656,7 +658,7 @@ void ProcedureWriter::writeApproachLeg(const ProcedureInput& line)
       approaches.last().record.setValue(":fix_region", fafInfo.region);
     }
 
-    if(waypointDescr.at(3) != " " && curRowCode == rc::APPROACH)
+    if(waypointDescr.at(3) != ' ' && curRowCode == rc::APPROACH)
       rec.setValue(":approach_fix_type", waypointDescr.at(3));
   }
 
@@ -903,7 +905,7 @@ float ProcedureWriter::altitudeFromStr(const QString& altStr)
 {
   if(altStr.startsWith("FL"))
     // Simplify - turn flight levelt to feet
-    return altStr.midRef(2).toFloat() * 100.f;
+    return altStr.mid(2).toFloat() * 100.f;
   else
     return altStr.toFloat();
 }

--- a/src/fs/common/xpgeometry.cpp
+++ b/src/fs/common/xpgeometry.cpp
@@ -18,6 +18,7 @@
 #include "fs/common/xpgeometry.h"
 
 #include <QDataStream>
+#include <QIODevice>
 
 using atools::geo::Pos;
 

--- a/src/fs/db/airwayresolver.cpp
+++ b/src/fs/db/airwayresolver.cpp
@@ -114,7 +114,7 @@ uint qHash(const AirwayResolver::AirwaySegment& segment)
          static_cast<unsigned int>(segment.toWaypointId) ^
          static_cast<unsigned int>(segment.minAlt) ^
          static_cast<unsigned int>(segment.maxAlt) ^
-         qHash(segment.type);
+         (uint)qHash(segment.type);
 }
 
 AirwayResolver::AirwayResolver(sql::SqlDatabase *sqlDb, atools::fs::ProgressHandler& progress)

--- a/src/fs/db/ap/apronwriter.cpp
+++ b/src/fs/db/ap/apronwriter.cpp
@@ -25,6 +25,8 @@
 #include "geo/linestring.h"
 #include "fs/common/binarygeometry.h"
 
+#include <QIODevice>
+
 namespace atools {
 namespace fs {
 namespace db {

--- a/src/fs/db/ap/deleteprocessor.cpp
+++ b/src/fs/db/ap/deleteprocessor.cpp
@@ -18,6 +18,7 @@
 #include "fs/db/ap/deleteprocessor.h"
 #include "sql/sqldatabase.h"
 #include "sql/sqlquery.h"
+#include "sql/sqlrecord.h"
 #include "geo/calculations.h"
 #include "sql/sqlutil.h"
 #include "fs/db/datawriter.h"
@@ -530,13 +531,15 @@ int DeleteProcessor::bindAndExecute(const QString& sql, const QString& msg)
 
 int DeleteProcessor::bindAndExecute(SqlQuery *query, const QString& msg)
 {
-  if(query->boundValues().contains(":prevApId"))
+  atools::sql::SqlRecord record = query->record();
+
+  if(record.contains("prevApId"))
     query->bindValue(":prevApId", prevAirportId);
 
-  if(query->boundValues().contains(":curApId"))
+  if(record.contains("curApId"))
     query->bindValue(":curApId", currentAirportId);
 
-  if(query->boundValues().contains(":apIdent"))
+  if(record.contains("apIdent"))
     query->bindValue(":apIdent", ident);
 
   return executeStatement(query, msg);

--- a/src/fs/db/meta/bglfilewriter.cpp
+++ b/src/fs/db/meta/bglfilewriter.cpp
@@ -42,7 +42,7 @@ void BglFileWriter::writeObject(const BglFile *type)
   bind(":bgl_file_id", getNextId());
   bind(":scenery_area_id", getDataWriter().getSceneryAreaWriter()->getCurrentId());
   bind(":bgl_create_time", static_cast<int>(type->getHeader().getCreationTimestamp()));
-  bind(":file_modification_time", static_cast<int>(fi.lastModified().toTime_t()));
+  bind(":file_modification_time", static_cast<int>(fi.lastModified().toSecsSinceEpoch()));
   bind(":filepath", QDir::toNativeSeparators(currentFilepath));
   bind(":filename", QDir::toNativeSeparators(currentFilename));
   bind(":size", type->getFilesize());

--- a/src/fs/db/routeedgewriter.cpp
+++ b/src/fs/db/routeedgewriter.cpp
@@ -161,7 +161,7 @@ void RouteEdgeWriter::run()
 
     total += toNodeIdVars.size();
     average = (average + toNodeIdVars.size()) / 2;
-    maximum = std::max(maximum, toNodeIdVars.size());
+    maximum = std::max((qsizetype)maximum, toNodeIdVars.size());
 
     if(toNodeIdVars.size() == 0)
       numEmpty++;
@@ -281,8 +281,8 @@ bool RouteEdgeWriter::nearest(SqlQuery& nearestStmt, int fromNodeId, const Pos& 
   {
     const QVector<TempNodeTo>& sectorReachable = sectorsReachable.value(sectorNum);
     const QVector<TempNodeTo>& sectorOther = sectorsOther.value(sectorNum);
-    int numOtherEntries = std::min(sectorOther.size(), MAX_EDGES_PER_SECTOR);
-    int numReachableEntries = std::min(sectorReachable.size(), MAX_EDGES_PER_SECTOR);
+    int numOtherEntries = std::min(sectorOther.size(), (qsizetype)MAX_EDGES_PER_SECTOR);
+    int numReachableEntries = std::min(sectorReachable.size(), (qsizetype)MAX_EDGES_PER_SECTOR);
 
     // We need more nodes for this sector
     if(numOtherEntries + numReachableEntries < MIN_EDGES_PER_SECTOR)

--- a/src/fs/db/runwayindex.cpp
+++ b/src/fs/db/runwayindex.cpp
@@ -23,7 +23,7 @@ namespace atools {
 namespace fs {
 namespace db {
 
-static QLatin1Literal NO_RWY("00");
+static QLatin1String NO_RWY("00");
 
 using std::make_pair;
 

--- a/src/fs/dfd/dfdcompiler.cpp
+++ b/src/fs/dfd/dfdcompiler.cpp
@@ -39,6 +39,8 @@
 #include <QDataStream>
 #include <QDebug>
 #include <QFileInfo>
+#include <QStringList>
+#include <QMetaType>
 
 using atools::fs::common::MagDecReader;
 using atools::fs::common::MetadataWriter;
@@ -155,7 +157,7 @@ void DfdCompiler::writeAirports()
     airportWriteQuery->bindValue(":file_id", FILE_ID);
     airportWriteQuery->bindValue(":ident", ident);
     if(iata.isEmpty())
-      airportWriteQuery->bindValue(":iata", QVariant::String);
+      airportWriteQuery->bindNullStr(":iata");
     else
       airportWriteQuery->bindValue(":iata", iata);
 
@@ -409,7 +411,7 @@ void DfdCompiler::pairRunways(QVector<std::pair<SqlRecord, SqlRecord> >& runwayp
     QString rname = rwident.mid(2);
 
     // Get pure number: 11
-    int rnum = rname.midRef(0, 2).toInt();
+    int rnum = rname.sliced(0, 2).toInt();
 
     // Get designator: R
     QString desig = rname.size() > 2 ? rname.at(2) : QString();
@@ -928,7 +930,7 @@ void DfdCompiler::finishAirspace()
         else
         {
           // Create an arc
-          bool clockwise = seg.via.isEmpty() ? true : seg.via.at(0) == "R";
+          bool clockwise = seg.via.isEmpty() ? true : seg.via.at(0) == 'R';
           curAirspaceLine.append(LineString(seg.center, seg.pos, nextPos, clockwise, 24));
         }
       }
@@ -1057,7 +1059,7 @@ void DfdCompiler::writeAirways()
 
     lastRec = airways.record();
     lastName = name;
-    lastEndOfRoute = code.size() > 1 && code.at(1) == "E";
+    lastEndOfRoute = code.size() > 1 && code.at(1) == 'E';
 
     if(nameChange)
     {

--- a/src/fs/fspaths.cpp
+++ b/src/fs/fspaths.cpp
@@ -196,7 +196,7 @@ void FsPaths::loadAllPaths()
 
 void FsPaths::intitialize()
 {
-  qRegisterMetaTypeStreamOperators<atools::fs::FsPaths::SimulatorType>();
+  qRegisterMetaType<atools::fs::FsPaths::SimulatorType>();
   environment = QProcessEnvironment::systemEnvironment();
 }
 
@@ -222,9 +222,9 @@ QString FsPaths::getMsfsOfficialPath()
 
 QString FsPaths::getMsfsOfficialPath(const QString& basePath)
 {
-  if(checkDir(basePath + SEP + "Official" + SEP + "OneStore"))
+  if(checkDir(QFileInfo(basePath + SEP + "Official" + SEP + "OneStore")))
     return basePath + SEP + "Official" + SEP + "OneStore";
-  else if(checkDir(basePath + SEP + "Official" + SEP + "Steam"))
+  else if(checkDir(QFileInfo(basePath + SEP + "Official" + SEP + "Steam")))
     return basePath + SEP + "Official" + SEP + "Steam";
   else
     return QString();
@@ -280,7 +280,7 @@ QString FsPaths::initBasePath(SimulatorType type)
     // C:\Users\USER\AppData\Local\Packages\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalCache\UserCfg.opt
     temp = msfsBasePath(environment.value("LOCALAPPDATA") + SEP + "Packages" + SEP +
                         "Microsoft.FlightSimulator_8wekyb3d8bbwe" + SEP + "LocalCache" + SEP + "UserCfg.opt");
-    if(checkDir(temp))
+    if(checkDir(QFileInfo(temp)))
     {
       fsPath = temp;
       qInfo() << Q_FUNC_INFO << "Found MSFS path" << fsPath;
@@ -294,7 +294,7 @@ QString FsPaths::initBasePath(SimulatorType type)
     // Steam installation ====================
     // C:\Users\USER\AppData\Roaming\Microsoft Flight Simulator\UserCfg.opt
     temp = msfsBasePath(environment.value("APPDATA") + SEP + "Microsoft Flight Simulator" + SEP + "UserCfg.opt");
-    if(checkDir(temp))
+    if(checkDir(QFileInfo(temp)))
     {
       fsPath = temp;
       qInfo() << Q_FUNC_INFO << "Found MSFS path" << fsPath;
@@ -307,7 +307,7 @@ QString FsPaths::initBasePath(SimulatorType type)
     // MS Boxed installation ====================
     // C:\Users\USER\AppData\Local\MSFSPackages\UserCfg.opt
     temp = msfsBasePath(environment.value("LOCALAPPDATA") + SEP + "MSFSPackages" + SEP + "UserCfg.opt");
-    if(checkDir(temp))
+    if(checkDir(QFileInfo(temp)))
     {
       fsPath = temp;
       qInfo() << Q_FUNC_INFO << "Found MSFS path" << fsPath;
@@ -344,10 +344,10 @@ QString FsPaths::initBasePath(SimulatorType type)
       // fsPath = ...\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalCache\Packages
       msfsCommunityPath = fsPath + SEP + "Community";
 
-      if(checkDir(fsPath + SEP + "Official" + SEP + "Steam"))
+      if(checkDir(QFileInfo(fsPath + SEP + "Official" + SEP + "Steam")))
         msfsOfficialPath = fsPath + SEP + "Official" + SEP + "Steam";
       // Find one of the official path variations for MS and Steam
-      else if(checkDir(fsPath + SEP + "Official" + SEP + "OneStore"))
+      else if(checkDir(QFileInfo(fsPath + SEP + "Official" + SEP + "OneStore")))
         msfsOfficialPath = fsPath + SEP + "Official" + SEP + "OneStore";
     }
   }
@@ -389,7 +389,7 @@ QString FsPaths::initBasePath(SimulatorType type)
 
     if(!fsPath.isEmpty())
     {
-      if(!checkDir(fsPath))
+      if(!checkDir(QFileInfo(fsPath)))
         fsPath.clear();
     }
     else
@@ -461,7 +461,7 @@ QString FsPaths::initFilesPath(SimulatorType type)
     case atools::fs::FsPaths::MSFS:
       // C:\Users\USER\AppData\Local\Packages\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalState
       fsFilesDir = msfsSimPath + SEP + "LocalState";
-      if(!checkDir(fsFilesDir))
+      if(!checkDir(QFileInfo(fsFilesDir)))
         // Steam uses top level as path
         // C:\Users\USER\AppData\Roaming\Microsoft Flight Simulator
         fsFilesDir = msfsSimPath;
@@ -802,7 +802,7 @@ QString FsPaths::msfsBasePath(const QString& userCfgOptFile)
   if(fileCfgOpt.open(QIODevice::ReadOnly | QIODevice::Text))
   {
     QTextStream stream(&fileCfgOpt);
-    stream.setCodec("UTF-8");
+    stream.setEncoding(QStringConverter::Utf8);
 
     while(!stream.atEnd())
     {
@@ -833,14 +833,14 @@ QString FsPaths::msfsBasePath(const QString& userCfgOptFile)
     if(!dir.isEmpty())
     {
       // Community
-      if(!checkDir(getMsfsCommunityPath(dir)))
+      if(!checkDir(QFileInfo(getMsfsCommunityPath(dir))))
         dir.clear();
 
       // Official/Steam or Official/OneStore
-      if(!checkDir(getMsfsOfficialPath(dir) + SEP + "fs-base"))
+      if(!checkDir(QFileInfo(getMsfsOfficialPath(dir) + SEP + "fs-base")))
         dir.clear();
 
-      if(!checkDir(getMsfsOfficialPath(dir) + SEP + "fs-base-nav"))
+      if(!checkDir(QFileInfo(getMsfsOfficialPath(dir) + SEP + "fs-base-nav")))
         dir.clear();
     }
   }
@@ -857,7 +857,7 @@ QString FsPaths::xplaneBasePath(const QString& installationFile)
   if(file.open(QIODevice::ReadOnly | QIODevice::Text))
   {
     QTextStream stream(&file);
-    stream.setCodec("UTF-8");
+    stream.setEncoding(QStringConverter::Utf8);
 
     while(!stream.atEnd())
     {

--- a/src/fs/navdatabase.cpp
+++ b/src/fs/navdatabase.cpp
@@ -174,7 +174,7 @@ void NavDatabase::createSchemaInternal(ProgressHandler *progress)
 
 bool NavDatabase::isSceneryConfigValid(const QString& filename, const QString& codec, QStringList& errors)
 {
-  errors.append(atools::checkFileMsg(filename));
+  errors.append(atools::checkFileMsg(QFileInfo(filename)));
   errors.removeAll(QString());
 
   if(errors.isEmpty())
@@ -207,17 +207,17 @@ bool NavDatabase::isSceneryConfigValid(const QString& filename, const QString& c
 bool NavDatabase::isBasePathValid(const QString& filepath, QStringList& errors, atools::fs::FsPaths::SimulatorType type)
 {
   if(type == atools::fs::FsPaths::XPLANE11)
-    errors.append(atools::checkDirMsg(buildPathNoCase({filepath, "Resources", "default data"})));
+    errors.append(atools::checkDirMsg(QFileInfo(buildPathNoCase({filepath, "Resources", "default data"}))));
   else if(type == atools::fs::FsPaths::MSFS)
   {
     // Base is C:\Users\alex\AppData\Local\Packages\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalCache\Packages
 
     // Check for both path variations in the official folder
-    QString baseMs = buildPathNoCase({filepath, "Official", "OneStore", "fs-base"});
-    QString baseNavMs = buildPathNoCase({filepath, "Official", "OneStore", "fs-base-nav"});
+    QFileInfo baseMs = QFileInfo(buildPathNoCase({filepath, "Official", "OneStore", "fs-base"}));
+    QFileInfo baseNavMs = QFileInfo(buildPathNoCase({filepath, "Official", "OneStore", "fs-base-nav"}));
 
-    QString baseSteam = buildPathNoCase({filepath, "Official", "Steam", "fs-base"});
-    QString baseNavSteam = buildPathNoCase({filepath, "Official", "Steam", "fs-base-nav"});
+    QFileInfo baseSteam = QFileInfo(buildPathNoCase({filepath, "Official", "Steam", "fs-base"}));
+    QFileInfo baseNavSteam = QFileInfo(buildPathNoCase({filepath, "Official", "Steam", "fs-base-nav"}));
 
     bool hasMs = checkDir(baseMs) && checkDir(baseNavMs);
     bool hasSteam = checkDir(baseSteam) && checkDir(baseNavSteam);
@@ -231,12 +231,12 @@ bool NavDatabase::isBasePathValid(const QString& filepath, QStringList& errors, 
       errors.append(atools::checkDirMsg(baseNavSteam));
     }
 
-    errors.append(atools::checkDirMsg(buildPathNoCase({filepath, "Community"})));
+    errors.append(atools::checkDirMsg(QFileInfo(buildPathNoCase({filepath, "Community"}))));
   }
   else
     // FSX and P3D ======================================================
     // If path exists check for scenery directory
-    errors.append(atools::checkDirMsg(buildPathNoCase({filepath, "scenery"})));
+    errors.append(atools::checkDirMsg(QFileInfo(buildPathNoCase({filepath, "scenery"}))));
 
   // Delete empty messages
   errors.removeAll(QString());
@@ -644,11 +644,11 @@ void NavDatabase::createInternal(const QString& sceneryConfigCodec)
 
     // Load the language index for lookup for airport names and more
     QString packageBase = options->getMsfsOfficialPath();
-    QFileInfo langFile = buildPathNoCase({packageBase, "fs-base", options->getLanguage() + ".locPak"});
+    QFileInfo langFile = QFileInfo(buildPathNoCase({packageBase, "fs-base", options->getLanguage() + ".locPak"}));
     if(!langFile.exists() || !langFile.isFile())
     {
       qWarning() << Q_FUNC_INFO << langFile.absoluteFilePath() << "not found. Falling back to en-US";
-      langFile = buildPathNoCase({packageBase, "fs-base", "en-US.locPak"});
+      langFile = QFileInfo(buildPathNoCase({packageBase, "fs-base", "en-US.locPak"}));
     }
 
     // Load translation file in current language for airport names ====================================
@@ -1270,52 +1270,52 @@ bool NavDatabase::createDatabaseReport(ProgressHandler *progress)
   if((aborted = progress->reportOther(tr("Creating table statistics"))))
     return true;
 
-  info << endl;
+  info << Qt::endl;
   util.printTableStats(info);
 
   if((aborted = progress->reportOther(tr("Creating report on values"))))
     return true;
 
-  info << endl;
+  info << Qt::endl;
   util.createColumnReport(info);
 
   if((aborted = progress->reportOther(tr("Creating report on duplicates"))))
     return true;
 
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "airport", "airport_id", {"ident"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "vor", "vor_id", {"ident", "region", "lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "ndb", "ndb_id", {"ident", "type", "frequency", "region", "lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "waypoint", "waypoint_id", {"ident", "type", "region", "lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "ils", "ils_id", {"ident", "lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "marker", "marker_id", {"type", "heading", "lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "helipad", "helipad_id", {"lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "parking", "parking_id", {"lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "start", "start_id", {"lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "runway", "runway_id", {"heading", "lonx", "laty"});
-  info << endl;
+  info << Qt::endl;
 
   util.reportDuplicates(info, "bgl_file", "bgl_file_id", {"filename"});
-  info << endl;
+  info << Qt::endl;
 
   if((aborted = progress->reportOther(tr("Creating report on coordinate duplicates"))))
     return true;
@@ -1345,12 +1345,12 @@ void NavDatabase::readSceneryConfigMsfs(atools::fs::scenery::SceneryCfg& cfg)
 
   // Steam: %APPDATA%\Microsoft Flight Simulator\Content.xml"
   QString contentXmlPath = options->getBasepath() + SEP + "Content.xml";
-  if(!atools::checkFile(contentXmlPath))
+  if(!atools::checkFile(QFileInfo(contentXmlPath)))
   {
     // Not found - try MS installation
     // Marketplace: %LOCALAPPDATA%\Packages\Microsoft.FlightSimulator_8wekyb3d8bbwe\LocalCache\Content.xml"
     contentXmlPath = QFileInfo(options->getBasepath() + SEP + ".." + SEP + "Content.xml").canonicalFilePath();
-    if(!atools::checkFile(contentXmlPath))
+    if(!atools::checkFile(QFileInfo(contentXmlPath)))
       // Not found
       contentXmlPath.clear();
   }
@@ -1606,7 +1606,7 @@ void NavDatabase::readSceneryConfigFsxP3d(atools::fs::scenery::SceneryCfg& cfg)
     // Mentioned in the SDK on "Add-on Packages" -> "Distributing an Add-on Package"
     // Mentioned in the SDK on "Add-on Instructions for Developers" -> "Add-on Directory Structure"
     addonDiscoveryPaths.prepend(documents + SEP + QString("Prepar3D v%1 Files").arg(simNum) +
-                                SEP + QLatin1Literal("add-ons"));
+                                SEP + QLatin1String("add-ons"));
 
     addonDiscoveryPaths.prepend(documents + SEP + QString("Prepar3D v%1 Add-ons").arg(simNum));
 
@@ -1666,7 +1666,7 @@ void NavDatabase::readSceneryConfigFsxP3d(atools::fs::scenery::SceneryCfg& cfg)
 
 QFileInfo NavDatabase::buildAddonFile(const QFileInfo& addonEntry)
 {
-  return QFileInfo(addonEntry.canonicalFilePath() + SEP + QLatin1Literal("add-on.xml"));
+  return QFileInfo(addonEntry.canonicalFilePath() + SEP + QLatin1String("add-on.xml"));
 }
 
 void NavDatabase::readAddOnComponents(int& areaNum, atools::fs::scenery::SceneryCfg& cfg,
@@ -1732,7 +1732,7 @@ void NavDatabase::reportCoordinateViolations(QDebug& out, atools::sql::SqlUtil& 
 {
   for(QString table : tables)
   {
-    out << "==================================================================" << endl;
+    out << "==================================================================" << Qt::endl;
     util.reportRangeViolations(out, table, {table + "_id", "ident"}, "lonx", -180.f, 180.f);
     util.reportRangeViolations(out, table, {table + "_id", "ident"}, "laty", -90.f, 90.f);
   }

--- a/src/fs/navdatabaseoptions.h
+++ b/src/fs/navdatabaseoptions.h
@@ -28,7 +28,6 @@
 #include <QMap>
 
 class QSettings;
-class QStringList;
 
 namespace atools {
 namespace fs {

--- a/src/fs/ns/navserverworker.cpp
+++ b/src/fs/ns/navserverworker.cpp
@@ -167,7 +167,7 @@ void NavServerWorker::postSimConnectData(atools::fs::sc::SimConnectData dataPack
     qWarning() << "NavServerWorker Reply to client not flushed";
 
   if(options & VERBOSE)
-    qDebug() << "NavServerWorker written" << written << "flush" << flush << "id" << dataPacket.getPacketId();
+    qDebug() << "NavServerWorker written" << written << "flush" << Qt::flush << "id" << dataPacket.getPacketId();
 
   inPost = false;
 }

--- a/src/fs/online/onlinetypes.cpp
+++ b/src/fs/online/onlinetypes.cpp
@@ -82,31 +82,31 @@ QString facilityTypeTextSettings(fac::FacilityType type)
   switch(type)
   {
     case atools::fs::online::fac::OBSERVER:
-      return QLatin1Literal("Observer");
+      return QLatin1String("Observer");
 
     case atools::fs::online::fac::FLIGHT_INFORMATION:
-      return QLatin1Literal("FIR");
+      return QLatin1String("FIR");
 
     case atools::fs::online::fac::DELIVERY:
-      return QLatin1Literal("Delivery");
+      return QLatin1String("Delivery");
 
     case atools::fs::online::fac::GROUND:
-      return QLatin1Literal("Ground");
+      return QLatin1String("Ground");
 
     case atools::fs::online::fac::TOWER:
-      return QLatin1Literal("Tower");
+      return QLatin1String("Tower");
 
     case atools::fs::online::fac::APPROACH:
-      return QLatin1Literal("Approach");
+      return QLatin1String("Approach");
 
     case atools::fs::online::fac::ACC:
-      return QLatin1Literal("ACC");
+      return QLatin1String("ACC");
 
     case atools::fs::online::fac::DEPARTURE:
-      return QLatin1Literal("Departure");
+      return QLatin1String("Departure");
 
     case atools::fs::online::fac::UNKNOWN:
-      return QLatin1Literal("Unknown");
+      return QLatin1String("Unknown");
   }
   return QString::number(type);
 }

--- a/src/fs/online/onlinetypes.h
+++ b/src/fs/online/onlinetypes.h
@@ -22,7 +22,6 @@
 #include <QVector>
 
 class QString;
-class QStringList;
 
 namespace atools {
 namespace geo {

--- a/src/fs/online/statustextparser.cpp
+++ b/src/fs/online/statustextparser.cpp
@@ -20,6 +20,7 @@
 #include <QDateTime>
 #include <QTextStream>
 #include <QDebug>
+#include <QIODevice>
 
 namespace atools {
 namespace fs {

--- a/src/fs/online/whazzuptextparser.cpp
+++ b/src/fs/online/whazzuptextparser.cpp
@@ -25,6 +25,7 @@
 #include "fs/common/binarygeometry.h"
 
 #include <QTextCodec>
+#include <QIODevice>
 
 using atools::sql::SqlDatabase;
 using atools::sql::SqlQuery;
@@ -254,9 +255,9 @@ void WhazzupTextParser::parseSection(const QStringList& line, bool isAtc, bool i
     QString alt = at(line, index, error).trimmed();
     if(alt.startsWith("FL"))
       // Convert flight level to altitude
-      insertQuery->bindValue(":altitude", alt.midRef(2).toInt() * 100);
-    else if(alt.startsWith("F"))
-      insertQuery->bindValue(":altitude", alt.midRef(1).toInt() * 100);
+      insertQuery->bindValue(":altitude", alt.sliced(2).toInt() * 100);
+    else if(alt.startsWith('F'))
+      insertQuery->bindValue(":altitude", alt.sliced(1).toInt() * 100);
     else
       insertQuery->bindValue(":altitude", alt.toInt());
   }

--- a/src/fs/perf/aircraftperf.cpp
+++ b/src/fs/perf/aircraftperf.cpp
@@ -34,7 +34,7 @@ namespace atools {
 namespace fs {
 namespace perf {
 
-const QLatin1Literal AircraftPerf::FORMAT_VERSION("2.4.0");
+const QLatin1String AircraftPerf::FORMAT_VERSION("2.4.0");
 
 float AircraftPerf::getTimeToClimb(float departureAltFt, float cruiseAltFt) const
 {
@@ -138,7 +138,7 @@ void AircraftPerf::saveXml(const QString& filename) const
 
 void AircraftPerf::saveXmlInternal(QXmlStreamWriter& writer) const
 {
-  writer.setCodec("UTF-8");
+  //writer.setEncoding(QStringConverter::Utf8);     // TODO: eval whether necessary
   writer.setAutoFormatting(true);
   writer.setAutoFormattingIndent(2);
 
@@ -248,101 +248,101 @@ void AircraftPerf::loadXmlInternal(atools::util::XmlStream& xmlStream)
   while(xmlStream.readNextStartElement())
   {
     // Read data from header =========================================
-    if(reader.name() == "Header")
+    if(reader.name().toString() == "Header")
     {
       // Skip header without warning
       xmlStream.skipCurrentElement();
       continue;
     }
-    else if(reader.name() == "Options")
+    else if(reader.name().toString() == "Options")
     {
       while(xmlStream.readNextStartElement())
       {
-        if(reader.name() == "Name")
+        if(reader.name().toString() == "Name")
           name = reader.readElementText();
-        else if(reader.name() == "AircraftType")
+        else if(reader.name().toString() == "AircraftType")
           type = reader.readElementText();
-        else if(reader.name() == "Description")
+        else if(reader.name().toString() == "Description")
           description = reader.readElementText();
-        else if(reader.name() == "FuelAsVolume")
+        else if(reader.name().toString() == "FuelAsVolume")
           volume = reader.readElementText().toInt();
-        else if(reader.name() == "JetFuel")
+        else if(reader.name().toString() == "JetFuel")
           jetFuel = reader.readElementText().toInt();
         else
           xmlStream.skipCurrentElement(true /* warn */);
       }
     }
-    else if(reader.name() == "Perf")
+    else if(reader.name().toString() == "Perf")
     {
       // Performance =======================================================
       while(xmlStream.readNextStartElement())
       {
-        if(reader.name() == "Alternate")
+        if(reader.name().toString() == "Alternate")
         {
           while(xmlStream.readNextStartElement())
           {
-            if(reader.name() == "FuelFlowLbsGalPerHour")
+            if(reader.name().toString() == "FuelFlowLbsGalPerHour")
               alternateFuelFlow = reader.readElementText().toFloat();
-            else if(reader.name() == "SpeedKtsTAS")
+            else if(reader.name().toString() == "SpeedKtsTAS")
               alternateSpeed = reader.readElementText().toFloat();
             else
               xmlStream.skipCurrentElement(true /* warn */);
           }
         }
-        else if(reader.name() == "Climb")
+        else if(reader.name().toString() == "Climb")
         {
           while(xmlStream.readNextStartElement())
           {
-            if(reader.name() == "FuelFlowLbsGalPerHour")
+            if(reader.name().toString() == "FuelFlowLbsGalPerHour")
               climbFuelFlow = reader.readElementText().toFloat();
-            else if(reader.name() == "SpeedKtsTAS")
+            else if(reader.name().toString() == "SpeedKtsTAS")
               climbSpeed = reader.readElementText().toFloat();
-            else if(reader.name() == "VertSpeedFtPerMin")
+            else if(reader.name().toString() == "VertSpeedFtPerMin")
               climbVertSpeed = reader.readElementText().toFloat();
             else
               xmlStream.skipCurrentElement(true /* warn */);
           }
         }
-        else if(reader.name() == "Cruise")
+        else if(reader.name().toString() == "Cruise")
         {
           while(xmlStream.readNextStartElement())
           {
-            if(reader.name() == "FuelFlowLbsGalPerHour")
+            if(reader.name().toString() == "FuelFlowLbsGalPerHour")
               cruiseFuelFlow = reader.readElementText().toFloat();
-            else if(reader.name() == "SpeedKtsTAS")
+            else if(reader.name().toString() == "SpeedKtsTAS")
               cruiseSpeed = reader.readElementText().toFloat();
             else
               xmlStream.skipCurrentElement(true /* warn */);
           }
         }
-        else if(reader.name() == "Descent")
+        else if(reader.name().toString() == "Descent")
         {
           while(xmlStream.readNextStartElement())
           {
-            if(reader.name() == "FuelFlowLbsGalPerHour")
+            if(reader.name().toString() == "FuelFlowLbsGalPerHour")
               descentFuelFlow = reader.readElementText().toFloat();
-            else if(reader.name() == "SpeedKtsTAS")
+            else if(reader.name().toString() == "SpeedKtsTAS")
               descentSpeed = reader.readElementText().toFloat();
-            else if(reader.name() == "VertSpeedFtPerMin")
+            else if(reader.name().toString() == "VertSpeedFtPerMin")
               descentVertSpeed = reader.readElementText().toFloat();
             else
               xmlStream.skipCurrentElement(true /* warn */);
           }
         }
         // Performance general ============================
-        else if(reader.name() == "ContingencyFuelPercent")
+        else if(reader.name().toString() == "ContingencyFuelPercent")
           contingencyFuel = reader.readElementText().toFloat();
-        else if(reader.name() == "ExtraFuelLbsGal")
+        else if(reader.name().toString() == "ExtraFuelLbsGal")
           extraFuel = reader.readElementText().toFloat();
-        else if(reader.name() == "MinRunwayLengthFt")
+        else if(reader.name().toString() == "MinRunwayLengthFt")
           minRunwayLength = reader.readElementText().toFloat();
-        else if(reader.name() == "ReserveFuelLbsGal")
+        else if(reader.name().toString() == "ReserveFuelLbsGal")
           reserveFuel = reader.readElementText().toFloat();
-        else if(reader.name() == "RunwayType")
+        else if(reader.name().toString() == "RunwayType")
           runwayType = runwayTypeFromStr(reader.readElementText());
-        else if(reader.name() == "TaxiFuelLbsGal")
+        else if(reader.name().toString() == "TaxiFuelLbsGal")
           taxiFuel = reader.readElementText().toFloat();
-        else if(reader.name() == "UsableFuelLbsGal")
+        else if(reader.name().toString() == "UsableFuelLbsGal")
           usableFuel = reader.readElementText().toFloat();
         else
           xmlStream.skipCurrentElement(true /* warn */);
@@ -354,7 +354,7 @@ void AircraftPerf::loadXmlInternal(atools::util::XmlStream& xmlStream)
 void AircraftPerf::loadIniInternal(const QString& filename)
 {
   QSettings settings(filename, QSettings::IniFormat);
-  settings.setIniCodec("UTF-8");
+  //settings.setIniCodec("UTF-8");        // TODO: eval whether still needed
   readFromSettings(settings);
 
   if(settings.status() != QSettings::NoError)
@@ -367,7 +367,7 @@ void AircraftPerf::saveIni(const QString& filename)
     QFile::remove(filename);
 
   QSettings settings(filename, QSettings::IniFormat);
-  settings.setIniCodec("UTF-8");
+  //settings.setIniCodec("UTF-8");          // see above
   writeToSettings(settings);
   settings.sync();
 

--- a/src/fs/perf/aircraftperf.h
+++ b/src/fs/perf/aircraftperf.h
@@ -316,7 +316,7 @@ public:
   }
 
   /* Current format */
-  const static QLatin1Literal FORMAT_VERSION;
+  const static QLatin1String FORMAT_VERSION;
 
   bool isJetFuel() const
   {

--- a/src/fs/pln/flightplan.cpp
+++ b/src/fs/pln/flightplan.cpp
@@ -188,7 +188,7 @@ QDebug operator<<(QDebug out, const Flightplan& record)
 
   int i = 1;
   for(const FlightplanEntry& entry : record.getEntries())
-    out << endl << i++ << " " << entry;
+    out << Qt::endl << i++ << " " << entry;
   out << "]";
   return out;
 }

--- a/src/fs/pln/flightplanconstants.h
+++ b/src/fs/pln/flightplanconstants.h
@@ -18,7 +18,7 @@
 #ifndef ATOOLS_FLIGHTPLANCONSTANTS_H
 #define ATOOLS_FLIGHTPLANCONSTANTS_H
 
-#include <QLatin1Literal>
+#include <QLatin1String>
 
 namespace atools {
 namespace fs {
@@ -98,32 +98,32 @@ enum RouteType
 /* Common key that are used int flight plan properties that are not supported in PLN.
  * Will be save inside a XML comment in pln files. */
 /* Keys that describe procedures*/
-const QLatin1Literal SIDAPPR("sidappr");
-const QLatin1Literal SIDAPPRRW("sidapprrw");
-const QLatin1Literal SIDTRANS("sidtrans");
+const QLatin1String SIDAPPR("sidappr");
+const QLatin1String SIDAPPRRW("sidapprrw");
+const QLatin1String SIDTRANS("sidtrans");
 
-const QLatin1Literal STAR("star");
-const QLatin1Literal STARRW("starrw");
-const QLatin1Literal STARTRANS("startrans");
+const QLatin1String STAR("star");
+const QLatin1String STARRW("starrw");
+const QLatin1String STARTRANS("startrans");
 
-const QLatin1Literal TRANSITION("transition");
-const QLatin1Literal TRANSITIONTYPE("transitiontype");
+const QLatin1String TRANSITION("transition");
+const QLatin1String TRANSITIONTYPE("transitiontype");
 
-const QLatin1Literal APPROACH("approach");
-const QLatin1Literal APPROACH_ARINC("approacharinc"); /* ARINC short name for FMS files */
-const QLatin1Literal APPROACHTYPE("approachtype");
-const QLatin1Literal APPROACHRW("approachrw");
-const QLatin1Literal APPROACHSUFFIX("approachsuffix");
+const QLatin1String APPROACH("approach");
+const QLatin1String APPROACH_ARINC("approacharinc"); /* ARINC short name for FMS files */
+const QLatin1String APPROACHTYPE("approachtype");
+const QLatin1String APPROACHRW("approachrw");
+const QLatin1String APPROACHSUFFIX("approachsuffix");
 
 /* Name of airway which leads to IAF of a STAR or an approach (-transition) */
-const QLatin1Literal PROCAIRWAY("procairway");
+const QLatin1String PROCAIRWAY("procairway");
 
 /* Only for approachtype = CUSTOM */
-const QLatin1Literal APPROACH_CUSTOM_DISTANCE("approachcustomdistance");
-const QLatin1Literal APPROACH_CUSTOM_ALTITUDE("approachcustomaltitude");
+const QLatin1String APPROACH_CUSTOM_DISTANCE("approachcustomdistance");
+const QLatin1String APPROACH_CUSTOM_ALTITUDE("approachcustomaltitude");
 
 /* List of alternate airport(s) separated by "#" */
-const QLatin1Literal ALTERNATES("alternates");
+const QLatin1String ALTERNATES("alternates");
 
 /* Copies all related properties and deletes the ones in "to" that do not exist in "from". */
 void copySidProcedureProperties(QHash<QString, QString>& to, const QHash<QString, QString>& from);
@@ -132,17 +132,17 @@ void copyStarProcedureProperties(QHash<QString, QString>& to, const QHash<QStrin
 void copyAlternateProperties(QHash<QString, QString>& to, const QHash<QString, QString>& from);
 
 /* Aircraft performance */
-const QLatin1Literal AIRCRAFT_PERF_NAME("aircraftperfname");
-const QLatin1Literal AIRCRAFT_PERF_TYPE("aircraftperftype");
-const QLatin1Literal AIRCRAFT_PERF_FILE("aircraftperffile");
+const QLatin1String AIRCRAFT_PERF_NAME("aircraftperfname");
+const QLatin1String AIRCRAFT_PERF_TYPE("aircraftperftype");
+const QLatin1String AIRCRAFT_PERF_FILE("aircraftperffile");
 
 /* Source database navigation data */
-const QLatin1Literal NAVDATA("navdata");
-const QLatin1Literal NAVDATACYCLE("navdatacycle");
+const QLatin1String NAVDATA("navdata");
+const QLatin1String NAVDATACYCLE("navdatacycle");
 
 /* Source database simulator */
-const QLatin1Literal SIMDATA("simdata");
-const QLatin1Literal SIMDATACYCLE("simdatacycle");
+const QLatin1String SIMDATA("simdata");
+const QLatin1String SIMDATACYCLE("simdatacycle");
 
 } // namespace pln
 } // namespace fs

--- a/src/fs/pln/flightplanio.cpp
+++ b/src/fs/pln/flightplanio.cpp
@@ -2185,64 +2185,64 @@ void FlightplanIO::saveFlpInternal(const atools::fs::pln::Flightplan& plan, cons
     stream.setCodec("UTF-8");
 
     // CoRte ==============================================
-    stream << "[CoRte]" << endl;
-    stream << "ArptDep=" << plan.departureIdent << endl;
-    stream << "ArptArr=" << plan.destinationIdent << endl;
+    stream << "[CoRte]" << Qt::endl;
+    stream << "ArptDep=" << plan.departureIdent << Qt::endl;
+    stream << "ArptArr=" << plan.destinationIdent << Qt::endl;
 
     // Departure - SID
     if(!plan.properties.value(SIDAPPRRW).isEmpty())
-      stream << "RwyDep=" << plan.departureIdent << plan.properties.value(SIDAPPRRW) << endl;
+      stream << "RwyDep=" << plan.departureIdent << plan.properties.value(SIDAPPRRW) << Qt::endl;
     else
-      stream << "RwyDep=" << endl;
+      stream << "RwyDep=" << Qt::endl;
 
     if(!plan.properties.value(SIDAPPR).isEmpty())
-      stream << "SID=" << plan.properties.value(SIDAPPR) << endl;
+      stream << "SID=" << plan.properties.value(SIDAPPR) << Qt::endl;
     else
-      stream << "SID=" << endl;
+      stream << "SID=" << Qt::endl;
 
     if(!plan.properties.value(SIDTRANS).isEmpty())
-      stream << "SID_Trans=" << plan.properties.value(SIDTRANS) << endl;
+      stream << "SID_Trans=" << plan.properties.value(SIDTRANS) << Qt::endl;
     else
-      stream << "SID_Trans=" << endl;
+      stream << "SID_Trans=" << Qt::endl;
 
     // Arrival STAR
     if(!plan.properties.value(STAR).isEmpty())
-      stream << "STAR=" << plan.properties.value(STAR) << endl;
+      stream << "STAR=" << plan.properties.value(STAR) << Qt::endl;
     else
-      stream << "STAR=" << endl;
+      stream << "STAR=" << Qt::endl;
 
     if(!plan.properties.value(STARTRANS).isEmpty())
-      stream << "STAR_Trans=" << plan.properties.value(STARTRANS) << endl;
+      stream << "STAR_Trans=" << plan.properties.value(STARTRANS) << Qt::endl;
     else
-      stream << "STAR_Trans=" << endl;
+      stream << "STAR_Trans=" << Qt::endl;
 
     // Arrival approach and transition
     if(!plan.properties.value(APPROACHRW).isEmpty())
-      stream << "RwyArr=" << plan.destinationIdent << plan.properties.value(APPROACHRW) << endl;
+      stream << "RwyArr=" << plan.destinationIdent << plan.properties.value(APPROACHRW) << Qt::endl;
     else
-      stream << "RwyArr=" << endl;
+      stream << "RwyArr=" << Qt::endl;
 
     if(!plan.properties.value(APPROACH).isEmpty())
-      stream << "RwyArrFinal=" << plan.properties.value(APPROACH) << endl;
+      stream << "RwyArrFinal=" << plan.properties.value(APPROACH) << Qt::endl;
     else
-      stream << "RwyArrFinal=" << endl;
+      stream << "RwyArrFinal=" << Qt::endl;
 
     if(!plan.properties.value(TRANSITION).isEmpty())
-      stream << "APPR_Trans=" << plan.properties.value(TRANSITION) << endl;
+      stream << "APPR_Trans=" << plan.properties.value(TRANSITION) << Qt::endl;
     else
-      stream << "APPR_Trans=" << endl;
+      stream << "APPR_Trans=" << Qt::endl;
 
-    // stream << "RwyDep=" << endl;
-    // stream << "RwyArr=" << endl;
-    // stream << "RwyArrFinal=" << endl;
-    // stream << "SID=" << endl;
-    // stream << "STAR=" << endl;
-    // stream << "APPR_Trans=" << endl;
+    // stream << "RwyDep=" << Qt::endl;
+    // stream << "RwyArr=" << Qt::endl;
+    // stream << "RwyArrFinal=" << Qt::endl;
+    // stream << "SID=" << Qt::endl;
+    // stream << "STAR=" << Qt::endl;
+    // stream << "APPR_Trans=" << Qt::endl;
 
     if(crj)
     {
-      stream << "CoRoute=" << endl;
-      stream << "FltNo=" << endl;
+      stream << "CoRoute=" << Qt::endl;
+      stream << "FltNo=" << Qt::endl;
     }
 
     QString lastAirwayTo;
@@ -2261,16 +2261,16 @@ void FlightplanIO::saveFlpInternal(const atools::fs::pln::Flightplan& plan, cons
 
       if(!next.getAirway().isEmpty())
       {
-        stream << "Airway" << index << "=" << next.getAirway() << endl;
-        stream << "Airway" << index << "FROM=" << entry.getIdent() << endl;
-        stream << "Airway" << index << "TO=" << next.getIdent() << endl;
+        stream << "Airway" << index << "=" << next.getAirway() << Qt::endl;
+        stream << "Airway" << index << "FROM=" << entry.getIdent() << Qt::endl;
+        stream << "Airway" << index << "TO=" << next.getIdent() << Qt::endl;
         lastAirwayTo = next.getIdent();
         index++;
       }
       else if(entry.getIdent() != lastAirwayTo)
       {
-        stream << "DctWpt" << index << "=" << identOrDegMinFormat(entry) << endl;
-        stream << "DctWpt" << index << "Coordinates=" << coords << endl;
+        stream << "DctWpt" << index << "=" << identOrDegMinFormat(entry) << Qt::endl;
+        stream << "DctWpt" << index << "Coordinates=" << coords << Qt::endl;
         lastAirwayTo.clear();
         index++;
       }
@@ -2279,27 +2279,27 @@ void FlightplanIO::saveFlpInternal(const atools::fs::pln::Flightplan& plan, cons
     if(crj)
     {
       // PerfData ==============================================
-      stream << "[PerfData]" << endl;
-      stream << "CrzAlt=" << plan.getCruisingAltitude() << endl;
-      stream << "CrzAltAltn=-1" << endl;
-      stream << "PaxCnt=-1" << endl;
-      stream << "PaxWeight=-1" << endl;
-      stream << "CargoWeight=-1" << endl;
-      stream << "FuelWeight=-1" << endl;
-      stream << "WindDirClb=0" << endl;
-      stream << "WindSpdClb=0" << endl;
-      stream << "WindDirCrz=0" << endl;
-      stream << "WindSpdCrz=0" << endl;
-      stream << "WindDirDes=0" << endl;
-      stream << "WindSpdDes=0" << endl;
-      stream << "ISADev=0" << endl;
-      stream << "ResFuel=-1" << endl;
-      stream << "TaxiFuel=-1" << endl;
+      stream << "[PerfData]" << Qt::endl;
+      stream << "CrzAlt=" << plan.getCruisingAltitude() << Qt::endl;
+      stream << "CrzAltAltn=-1" << Qt::endl;
+      stream << "PaxCnt=-1" << Qt::endl;
+      stream << "PaxWeight=-1" << Qt::endl;
+      stream << "CargoWeight=-1" << Qt::endl;
+      stream << "FuelWeight=-1" << Qt::endl;
+      stream << "WindDirClb=0" << Qt::endl;
+      stream << "WindSpdClb=0" << Qt::endl;
+      stream << "WindDirCrz=0" << Qt::endl;
+      stream << "WindSpdCrz=0" << Qt::endl;
+      stream << "WindDirDes=0" << Qt::endl;
+      stream << "WindSpdDes=0" << Qt::endl;
+      stream << "ISADev=0" << Qt::endl;
+      stream << "ResFuel=-1" << Qt::endl;
+      stream << "TaxiFuel=-1" << Qt::endl;
 
       // VNAVData ==============================================
-      stream << "[VNAVData]" << endl;
-      stream << "TransAlt=18000" << endl;
-      stream << "TransLvl=18000" << endl;
+      stream << "[VNAVData]" << Qt::endl;
+      stream << "TransAlt=18000" << Qt::endl;
+      stream << "TransLvl=18000" << Qt::endl;
     }
 
     flpFile.close();
@@ -2359,22 +2359,22 @@ void FlightplanIO::saveFeelthereFpl(const atools::fs::pln::Flightplan& plan, con
     stream.setCodec("UTF-8");
     stream.setRealNumberPrecision(8);
 
-    stream << "; " << programFileInfo() << endl;
-    stream << "[Origin]" << endl;
-    stream << "ident=" << plan.departureIdent << endl;
-    stream << "type=1" << endl;
-    stream << "latitude=" << plan.entries.first().getPosition().getLatY() << endl;
-    stream << "longitude=" << plan.entries.first().getPosition().getLonX() << endl;
+    stream << "; " << programFileInfo() << Qt::endl;
+    stream << "[Origin]" << Qt::endl;
+    stream << "ident=" << plan.departureIdent << Qt::endl;
+    stream << "type=1" << Qt::endl;
+    stream << "latitude=" << plan.entries.first().getPosition().getLatY() << Qt::endl;
+    stream << "longitude=" << plan.entries.first().getPosition().getLonX() << Qt::endl;
 
-    stream << "[Destination]" << endl;
-    stream << "ident=" << plan.destinationIdent << endl;
-    stream << "type=1" << endl;
-    stream << "latitude=" << plan.entries.last().getPosition().getLatY() << endl;
-    stream << "longitude=" << plan.entries.last().getPosition().getLonX() << endl;
+    stream << "[Destination]" << Qt::endl;
+    stream << "ident=" << plan.destinationIdent << Qt::endl;
+    stream << "type=1" << Qt::endl;
+    stream << "latitude=" << plan.entries.last().getPosition().getLatY() << Qt::endl;
+    stream << "longitude=" << plan.entries.last().getPosition().getLonX() << Qt::endl;
 
-    stream << "[Route]" << endl;
-    stream << "gspd=" << groundSpeed << endl;
-    stream << "countOfPoints=" << (numEntriesSave(plan) - 1) << endl;
+    stream << "[Route]" << Qt::endl;
+    stream << "gspd=" << groundSpeed << Qt::endl;
+    stream << "countOfPoints=" << (numEntriesSave(plan) - 1) << Qt::endl;
 
     int index = 0;
     for(int i = 1; i < plan.entries.size(); i++)
@@ -2385,10 +2385,10 @@ void FlightplanIO::saveFeelthereFpl(const atools::fs::pln::Flightplan& plan, con
         continue;
 
       QString prefix = QString("Wpt.%1.").arg(index, 2, 10, QChar('0'));
-      stream << prefix << "ident=" << identOrDegMinFormat(entry) << endl;
-      stream << prefix << "type=" << (i == plan.entries.size() - 1 ? "1" : "4") << endl;
-      stream << prefix << "latitude=" << entry.getPosition().getLatY() << endl;
-      stream << prefix << "longitude=" << entry.getPosition().getLonX() << endl;
+      stream << prefix << "ident=" << identOrDegMinFormat(entry) << Qt::endl;
+      stream << prefix << "type=" << (i == plan.entries.size() - 1 ? "1" : "4") << Qt::endl;
+      stream << prefix << "latitude=" << entry.getPosition().getLatY() << Qt::endl;
+      stream << prefix << "longitude=" << entry.getPosition().getLonX() << Qt::endl;
 
       index++;
     }
@@ -2427,7 +2427,7 @@ void FlightplanIO::saveLeveldRte(const atools::fs::pln::Flightplan& plan, const 
     stream.setCodec("UTF-8");
     stream.setRealNumberPrecision(8);
 
-    stream << "H," << plan.departureIdent << "," << plan.destinationIdent << ", ," << endl;
+    stream << "H," << plan.departureIdent << "," << plan.destinationIdent << ", ," << Qt::endl;
 
     for(int i = 0; i < plan.entries.size(); i++)
     {
@@ -2439,10 +2439,10 @@ void FlightplanIO::saveLeveldRte(const atools::fs::pln::Flightplan& plan, const 
       stream << "W," << identOrDegMinFormat(entry) << "," << entry.getAirway() << ",30,"
              << QString("%1").arg(entry.getPosition().getLatY(), 0, 'f', 6, QChar('0')) << ","
              << QString("%1").arg(entry.getPosition().getLonX(), 0, 'f', 6, QChar('0'))
-             << ",0.000000,0.000000,0,0,0,0" << endl;
+             << ",0.000000,0.000000,0,0,0,0" << Qt::endl;
     }
 
-    stream << endl << endl << "End of FlightPlan";
+    stream << Qt::endl << Qt::endl << "End of FlightPlan";
 
     rteFile.close();
   }
@@ -2492,18 +2492,18 @@ void FlightplanIO::saveEfbr(const Flightplan& plan, const QString& filename, con
     stream.setCodec("UTF-8");
     stream.setRealNumberPrecision(8);
 
-    stream << "[AivlaSoft EFB Route - www.aivlasoft.com]" << endl;
-    stream << "//Saved " << QDateTime::currentDateTimeUtc().toString("yyyy-MM-dd HH:mm:ss'z'") << endl;
-    stream << "//AIRAC cycle " << cycle << endl;
-    stream << "Format=1" << endl;
-    stream << "ATS=" << route << endl;
-    stream << "Generator=" << QApplication::applicationName() << endl;
-    stream << "Origin=" << plan.departureIdent << endl;
-    stream << "Destination=" << plan.destinationIdent << endl;
-    stream << "CruiseAltitude=" << plan.getCruisingAltitude() << endl;
-    stream << "DepartureProcedureInfo=" << departureRw << "|||" << endl;
-    stream << "ArrivalProcedureInfo=" << destinationRw << "||" << endl;
-    stream << "ApproachProcedureInfo=||" << endl;
+    stream << "[AivlaSoft EFB Route - www.aivlasoft.com]" << Qt::endl;
+    stream << "//Saved " << QDateTime::currentDateTimeUtc().toString("yyyy-MM-dd HH:mm:ss'z'") << Qt::endl;
+    stream << "//AIRAC cycle " << cycle << Qt::endl;
+    stream << "Format=1" << Qt::endl;
+    stream << "ATS=" << route << Qt::endl;
+    stream << "Generator=" << QApplication::applicationName() << Qt::endl;
+    stream << "Origin=" << plan.departureIdent << Qt::endl;
+    stream << "Destination=" << plan.destinationIdent << Qt::endl;
+    stream << "CruiseAltitude=" << plan.getCruisingAltitude() << Qt::endl;
+    stream << "DepartureProcedureInfo=" << departureRw << "|||" << Qt::endl;
+    stream << "ArrivalProcedureInfo=" << destinationRw << "||" << Qt::endl;
+    stream << "ApproachProcedureInfo=||" << Qt::endl;
 
     int num = 0;
     for(int i = 0; i < plan.entries.size(); i++)
@@ -2543,7 +2543,7 @@ void FlightplanIO::saveEfbr(const Flightplan& plan, const QString& filename, con
       stream << "|" << frequency << "|" << entry.getRegion() << "|"
              << QString("%1").arg(entry.getPosition().getLatY(), 0, 'f', 6, QChar('0')) << "|"
              << QString("%1").arg(entry.getPosition().getLonX(), 0, 'f', 6,
-                           QChar('0')) << "|0|" << (entry.getAirway().isEmpty() ? "DCT" : entry.getAirway()) << endl;
+                           QChar('0')) << "|0|" << (entry.getAirway().isEmpty() ? "DCT" : entry.getAirway()) << Qt::endl;
 
       num++;
     }
@@ -2593,7 +2593,7 @@ void FlightplanIO::saveQwRte(const Flightplan& plan, const QString& filename)
     stream.setCodec("UTF-8");
     stream.setRealNumberPrecision(8);
 
-    stream << "[FlightPlan]" << endl;
+    stream << "[FlightPlan]" << Qt::endl;
 
     for(int i = 0; i < plan.entries.size(); i++)
     {
@@ -2633,7 +2633,7 @@ void FlightplanIO::saveQwRte(const Flightplan& plan, const QString& filename)
       stream << QString("%1").arg(identOrDegMinFormat(entry), -17)
              << QString("%1").arg(entry.getPosition().getLatY(), 0, 'f', 6, QChar('0')) << "  "
              << QString("%1").arg(entry.getPosition().getLonX(), 0, 'f', 6, QChar('0')) << "  "
-             << type << " " << frequency << "    " << entry.getAirway() << endl;
+             << type << " " << frequency << "    " << entry.getAirway() << Qt::endl;
     }
 
     rteFile.close();
@@ -2660,8 +2660,8 @@ void FlightplanIO::saveMdr(const Flightplan& plan, const QString& filename)
     QTextStream stream(&mdrFile);
     stream.setCodec("UTF-8");
 
-    stream << plan.departureIdent << endl;
-    stream << plan.destinationIdent << endl;
+    stream << plan.departureIdent << Qt::endl;
+    stream << plan.destinationIdent << Qt::endl;
 
     QString lastAirway;
     for(int i = 1; i < plan.entries.size(); i++)
@@ -2681,7 +2681,7 @@ void FlightplanIO::saveMdr(const Flightplan& plan, const QString& filename)
         // Airway has changed - print the last waypoint
         stream << lastAirway << " " << prev.getIdent() << " " << QString("%1 %2").
           arg(prev.getPosition().getLatY(), 0, 'f', 6).
-          arg(prev.getPosition().getLonX(), 0, 'f', 6) << endl;
+          arg(prev.getPosition().getLonX(), 0, 'f', 6) << Qt::endl;
 
       if(entry.getAirway().isEmpty() && i != plan.entries.size() - 1)
       {
@@ -2690,7 +2690,7 @@ void FlightplanIO::saveMdr(const Flightplan& plan, const QString& filename)
                          arg(entry.getPosition().getLatY(), 0, 'f', 6).
                          arg(entry.getPosition().getLonX(), 0, 'f', 6);
 
-        stream << "DIRECT" << " " << identOrDegMinFormat(entry) << " " << coords << endl;
+        stream << "DIRECT" << " " << identOrDegMinFormat(entry) << " " << coords << Qt::endl;
       }
       lastAirway = entry.getAirway();
     }
@@ -3093,13 +3093,13 @@ void FlightplanIO::saveFmsInternal(const atools::fs::pln::Flightplan& plan, cons
     stream.setCodec("UTF-8");
 
     // OS
-    stream << "I" << endl;
+    stream << "I" << Qt::endl;
 
     // File version
     if(version11Format)
     {
       // New X-Plane 11 format
-      stream << "1100 Version" << endl;
+      stream << "1100 Version" << Qt::endl;
 
       QString cycle = plan.properties.value(NAVDATACYCLE);
       if(cycle.isEmpty())
@@ -3108,63 +3108,63 @@ void FlightplanIO::saveFmsInternal(const atools::fs::pln::Flightplan& plan, cons
         // Fake a cycle by using current year and month
         cycle = QLocale(QLocale::C).toString(QDateTime::currentDateTime(), "yyMM");
 
-      stream << "CYCLE " << cycle << endl;
+      stream << "CYCLE " << cycle << Qt::endl;
 
       // Departure
       QString departureIdent = plan.getDepartureIdent();
       if(plan.entries.first().getWaypointType() == entry::AIRPORT && departureIdent.size() <= 4)
-        stream << "ADEP " << departureIdent << endl;
+        stream << "ADEP " << departureIdent << Qt::endl;
       else
-        stream << "DEP " << departureIdent << endl;
+        stream << "DEP " << departureIdent << Qt::endl;
 
       // Departure - SID
       if(!plan.properties.value(SIDAPPRRW).isEmpty())
-        stream << "DEPRWY RW" << plan.properties.value(SIDAPPRRW) << endl;
+        stream << "DEPRWY RW" << plan.properties.value(SIDAPPRRW) << Qt::endl;
 
       if(!plan.properties.value(SIDAPPR).isEmpty())
-        stream << "SID " << plan.properties.value(SIDAPPR) << endl;
+        stream << "SID " << plan.properties.value(SIDAPPR) << Qt::endl;
 
       if(!plan.properties.value(SIDTRANS).isEmpty())
-        stream << "SIDTRANS " << plan.properties.value(SIDTRANS) << endl;
+        stream << "SIDTRANS " << plan.properties.value(SIDTRANS) << Qt::endl;
 
       // Destination
       QString destinationIdent = plan.getDestinationIdent();
       if(plan.entries.last().getWaypointType() == entry::AIRPORT && destinationIdent.size() <= 4)
-        stream << "ADES " << destinationIdent << endl;
+        stream << "ADES " << destinationIdent << Qt::endl;
       else
-        stream << "DES " << destinationIdent << endl;
+        stream << "DES " << destinationIdent << Qt::endl;
 
       // Arrival runway
       if(!plan.properties.value(APPROACHRW).isEmpty())
         // Use approach runway if there is an approach
-        stream << "DESRWY RW" << plan.properties.value(APPROACHRW) << endl;
+        stream << "DESRWY RW" << plan.properties.value(APPROACHRW) << Qt::endl;
       else if(!plan.properties.value(STARRW).isEmpty())
         // Use STAR runway if no approach but STAR
-        stream << "DESRWY RW" << plan.properties.value(STARRW) << endl;
+        stream << "DESRWY RW" << plan.properties.value(STARRW) << Qt::endl;
 
       // Arrival approach and transition
       // Arrival STAR
       if(!plan.properties.value(STAR).isEmpty())
-        stream << "STAR " << plan.properties.value(STAR) << endl;
+        stream << "STAR " << plan.properties.value(STAR) << Qt::endl;
 
       if(!plan.properties.value(STARTRANS).isEmpty())
-        stream << "STARTRANS " << plan.properties.value(STARTRANS) << endl;
+        stream << "STARTRANS " << plan.properties.value(STARTRANS) << Qt::endl;
 
       // Approach
       if(!plan.properties.value(APPROACH_ARINC).isEmpty())
-        stream << "APP " << plan.properties.value(APPROACH_ARINC) << endl;
+        stream << "APP " << plan.properties.value(APPROACH_ARINC) << Qt::endl;
 
       if(!plan.properties.value(TRANSITION).isEmpty())
-        stream << "APPTRANS " << plan.properties.value(TRANSITION) << endl;
+        stream << "APPTRANS " << plan.properties.value(TRANSITION) << Qt::endl;
 
       // Number of waypoints
-      stream << "NUMENR " << numEntries << endl;
+      stream << "NUMENR " << numEntries << Qt::endl;
     }
     else
     {
-      stream << "3 version" << endl;
-      stream << "1" << endl;
-      stream << (numEntries - 1) << endl; // Number of waypoints
+      stream << "3 version" << Qt::endl;
+      stream << "1" << Qt::endl;
+      stream << (numEntries - 1) << Qt::endl; // Number of waypoints
     }
 
     int index = 0;
@@ -3222,7 +3222,7 @@ void FlightplanIO::saveFmsInternal(const atools::fs::pln::Flightplan& plan, cons
              << QString::number(entry.getPosition().getLatY(), 'f', 6)
              << " "
              << QString::number(entry.getPosition().getLonX(), 'f', 6)
-             << endl;
+             << Qt::endl;
 
       index++;
     }
@@ -3263,20 +3263,20 @@ void FlightplanIO::saveRte(const atools::fs::pln::Flightplan& plan, const QStrin
       arg(QApplication::applicationVersion()).
       arg(atools::gitRevision()).
       arg(QDateTime::currentDateTime().toString(Qt::ISODate)).
-      replace("-", " ") << endl << endl;
+      replace("-", " ") << Qt::endl << Qt::endl;
 
-    stream << numEntriesSave(plan) << endl << endl;
+    stream << numEntriesSave(plan) << Qt::endl << Qt::endl;
 
-    stream << plan.departureIdent << endl << AIRPORT << endl << "DIRECT" << endl;
+    stream << plan.departureIdent << Qt::endl << AIRPORT << Qt::endl << "DIRECT" << Qt::endl;
     posToRte(stream, plan.entries.first().getPosition(), true);
-    stream << endl << NO_DATA_STR << endl
-           << 1 /* Departure*/ << endl << 0 /* Runway position */ << endl << endl;
+    stream << Qt::endl << NO_DATA_STR << Qt::endl
+           << 1 /* Departure*/ << Qt::endl << 0 /* Runway position */ << Qt::endl << Qt::endl;
 
-    stream << CLIMB << endl; // Restriction phase climb
+    stream << CLIMB << Qt::endl; // Restriction phase climb
     stream << atools::roundToInt(plan.entries.first().getPosition().getAltitude()); // Restriction altitude, if restricted
 
     // Restriction type, altitude and speed
-    stream << endl << NO_DATA_STR << endl << NO_DATA_NUM << endl << NO_DATA_NUM << endl << endl;
+    stream << Qt::endl << NO_DATA_STR << Qt::endl << NO_DATA_NUM << Qt::endl << NO_DATA_NUM << Qt::endl << Qt::endl;
 
     for(int i = 1; i < plan.entries.size() - 1; i++)
     {
@@ -3288,31 +3288,31 @@ void FlightplanIO::saveRte(const atools::fs::pln::Flightplan& plan, const QStrin
 
       if(entry.getWaypointType() == ple::USER)
       {
-        stream << "WPT" << userWaypointNum++ << endl;
-        stream << OTHER << endl;
+        stream << "WPT" << userWaypointNum++ << Qt::endl;
+        stream << OTHER << Qt::endl;
       }
       else
       {
-        stream << (entry.getIdent().isEmpty() ? NO_DATA_STR : entry.getIdent()) << endl;
-        stream << (entry.getWaypointType() == ple::AIRPORT ? AIRPORT : WAYPOINT) << endl;
+        stream << (entry.getIdent().isEmpty() ? NO_DATA_STR : entry.getIdent()) << Qt::endl;
+        stream << (entry.getWaypointType() == ple::AIRPORT ? AIRPORT : WAYPOINT) << Qt::endl;
       }
 
       QString nextAirway = plan.entries.at(i + 1).getAirway();
-      stream << (nextAirway.isEmpty() ? "DIRECT" : nextAirway) << endl;
+      stream << (nextAirway.isEmpty() ? "DIRECT" : nextAirway) << Qt::endl;
 
       posToRte(stream, entry.getPosition(), false);
-      stream << endl << 0 << endl << 0 << endl << 0 << endl << endl; // Restriction fields
+      stream << Qt::endl << 0 << Qt::endl << 0 << Qt::endl << 0 << Qt::endl << Qt::endl; // Restriction fields
     }
 
-    stream << plan.destinationIdent << endl << AIRPORT << endl << NO_DATA_STR << endl;
+    stream << plan.destinationIdent << Qt::endl << AIRPORT << Qt::endl << NO_DATA_STR << Qt::endl;
     posToRte(stream, plan.destinationPos, true);
-    stream << endl << NO_DATA_STR << endl
-           << 0 /* no departure*/ << endl << 0 /* Runway position */ << endl << endl;
+    stream << Qt::endl << NO_DATA_STR << Qt::endl
+           << 0 /* no departure*/ << Qt::endl << 0 /* Runway position */ << Qt::endl << Qt::endl;
 
-    stream << CLIMB << endl; // Restriction phase
-    stream << atools::roundToInt(plan.destinationPos.getAltitude()) << endl; // Restriction altitude, if restricted
+    stream << CLIMB << Qt::endl; // Restriction phase
+    stream << atools::roundToInt(plan.destinationPos.getAltitude()) << Qt::endl; // Restriction altitude, if restricted
     // Restriction type, altitude and speed
-    stream << NO_DATA_STR << endl << NO_DATA_NUM << endl << NO_DATA_NUM << endl;
+    stream << NO_DATA_STR << Qt::endl << NO_DATA_NUM << Qt::endl << NO_DATA_NUM << Qt::endl;
 
 #ifndef Q_OS_WIN32
     // Convert EOL always to Windows (0x0a -> 0x0d0a)
@@ -3455,13 +3455,13 @@ void FlightplanIO::saveFltplan(const Flightplan& plan, const QString& filename)
 
     // YSSY,
     // YMML,
-    stream << plan.getDepartureIdent() << "," << endl << plan.getDestinationIdent() << "," << endl;
+    stream << plan.getDepartureIdent() << "," << Qt::endl << plan.getDestinationIdent() << "," << Qt::endl;
 
     // ,
-    stream << "," << endl;
+    stream << "," << Qt::endl;
 
     // 32000,
-    stream << plan.getCruisingAltitude() << "," << endl;
+    stream << plan.getCruisingAltitude() << "," << Qt::endl;
 
     // ,
     // ,
@@ -3469,7 +3469,7 @@ void FlightplanIO::saveFltplan(const Flightplan& plan, const QString& filename)
     // ,
     // ,
     // ,
-    stream << "," << endl << "," << endl << "," << endl << "," << endl << "," << endl << "," << endl;
+    stream << "," << Qt::endl << "," << Qt::endl << "," << Qt::endl << "," << Qt::endl << "," << Qt::endl << "," << Qt::endl;
 
     // -1,
     // ,
@@ -3477,7 +3477,7 @@ void FlightplanIO::saveFltplan(const Flightplan& plan, const QString& filename)
     // ,
     // ,
     // -1,
-    stream << "-1," << endl << "," << endl << "," << endl << "," << endl << "," << endl << "0," << endl;
+    stream << "-1," << Qt::endl << "," << Qt::endl << "," << Qt::endl << "," << Qt::endl << "," << Qt::endl << "0," << Qt::endl;
 
     for(int i = 0; i < plan.entries.size(); i++)
     {
@@ -3522,7 +3522,7 @@ void FlightplanIO::saveFltplan(const Flightplan& plan, const QString& filename)
       // Ignore rest of the fields
       stream << ",0,0,1,-1,0.000,0,-1000,-1000,-1,-1,-1,0,0,000.00000,0,0,,"
                 "-1000,-1,-1,-1000,0,-1000,-1,-1,-1000,0,-1000,-1,-1,-1000,0,-1000,-1,-1,-1000,0,-1000,-1000,0,";
-      stream << endl;
+      stream << Qt::endl;
     }
 
 #ifndef Q_OS_WIN32
@@ -3568,24 +3568,24 @@ void FlightplanIO::saveBbsPln(const Flightplan& plan, const QString& filename)
     // description=EDDH, LIRF
     // type=IFR
     // routetype=3
-    stream << "[flightplan]" << endl;
-    stream << "title=" << plan.getDepartureIdent() << " to " << plan.getDestinationIdent() << endl;
-    stream << "description=" << plan.getDepartureIdent() << ", " << plan.getDestinationIdent() << endl;
-    stream << "type=" << flightplanTypeToString(plan.getFlightplanType()) << endl;
-    stream << "routetype=3" << endl;
+    stream << "[flightplan]" << Qt::endl;
+    stream << "title=" << plan.getDepartureIdent() << " to " << plan.getDestinationIdent() << Qt::endl;
+    stream << "description=" << plan.getDepartureIdent() << ", " << plan.getDestinationIdent() << Qt::endl;
+    stream << "type=" << flightplanTypeToString(plan.getFlightplanType()) << Qt::endl;
+    stream << "routetype=3" << Qt::endl;
 
     // cruising_altitude=29000
     // departure_id=EDDH, N53* 37.82', E009* 59.29', +000053.00
     // destination_id=LIRF, N41* 48.02', E012* 14.33', +000014.00
     // departure_name=HAMBURG
     // destination_name=FIUMICINO
-    stream << "cruising_altitude=" << plan.getCruisingAltitude() << endl;
+    stream << "cruising_altitude=" << plan.getCruisingAltitude() << Qt::endl;
     stream << "departure_id=" << plan.getDepartureIdent() << ", "
-           << coordStringFs9(plan.getDeparturePosition()) << endl;
+           << coordStringFs9(plan.getDeparturePosition()) << Qt::endl;
     stream << "destination_id=" << plan.getDestinationIdent() << ", "
-           << coordStringFs9(plan.getDestinationPosition()) << endl;
-    stream << "departure_name=" << plan.departNameOrIdent().toUpper() << endl;
-    stream << "destination_name=" << plan.destNameOrIdent().toUpper() << endl;
+           << coordStringFs9(plan.getDestinationPosition()) << Qt::endl;
+    stream << "departure_name=" << plan.departNameOrIdent().toUpper() << Qt::endl;
+    stream << "destination_name=" << plan.destNameOrIdent().toUpper() << Qt::endl;
 
     // waypoint.0=EDDH, A, N53* 37.82', E009* 59.29', +000053.00,
     // waypoint.1=AMLUH, I, N53* 25.74', E010* 19.35', +000000.00,
@@ -3604,7 +3604,7 @@ void FlightplanIO::saveBbsPln(const Flightplan& plan, const QString& filename)
       stream << coordStringFs9(entry.getPosition()) << ", ";
       stream << entry.getAirway();
 
-      stream << endl;
+      stream << Qt::endl;
       idx++;
     }
 

--- a/src/fs/sc/datareaderthread.cpp
+++ b/src/fs/sc/datareaderthread.cpp
@@ -289,7 +289,7 @@ bool DataReaderThread::fetchData(atools::fs::sc::SimConnectData& data, int radiu
     data.setPacketId(nextPacketId++);
   }
 
-  data.setPacketTimestamp(QDateTime::currentDateTime().toTime_t());
+  data.setPacketTimestamp(QDateTime::currentDateTime().toSecsSinceEpoch());
 
   if(verbose)
     if(weatherRequested && !data.getMetars().isEmpty())

--- a/src/fs/sc/simconnectapi.cpp
+++ b/src/fs/sc/simconnectapi.cpp
@@ -21,7 +21,9 @@
 
 #include <QDebug>
 
+#if ! _MSC_VER || __INTEL_COMPILER                      // intel compiler defines _MSC_VER, didn't check whether it supports GCC
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 
 #define BINDSC(a) (error |= \
                      ((*(FARPROC *)&SC_ ## a = \
@@ -185,7 +187,7 @@ HRESULT SimConnectApi::SetSystemEventState(SIMCONNECT_CLIENT_EVENT_ID EventID, S
 
 HRESULT SimConnectApi::AddClientEventToNotificationGroup(SIMCONNECT_NOTIFICATION_GROUP_ID GroupID,
                                                          SIMCONNECT_CLIENT_EVENT_ID EventID,
-                                                         WINBOOL bMaskable)
+                                                         BOOL2 bMaskable)
 {
   if(hSimConnect == NULL || SC_AddClientEventToNotificationGroup == nullptr)
     return E_FAIL;
@@ -279,7 +281,7 @@ HRESULT SimConnectApi::SetDataOnSimObject(SIMCONNECT_DATA_DEFINITION_ID DefineID
 HRESULT SimConnectApi::MapInputEventToClientEvent(SIMCONNECT_INPUT_GROUP_ID GroupID, const char *szInputDefinition,
                                                   SIMCONNECT_CLIENT_EVENT_ID DownEventID, DWORD DownValue,
                                                   SIMCONNECT_CLIENT_EVENT_ID UpEventID, DWORD UpValue,
-                                                  WINBOOL bMaskable)
+                                                  BOOL2 bMaskable)
 {
   if(hSimConnect == NULL || SC_MapInputEventToClientEvent == nullptr)
     return E_FAIL;
@@ -485,7 +487,7 @@ HRESULT SimConnectApi::AICreateParkedATCAircraft(const char *szContainerTitle, c
 
 HRESULT SimConnectApi::AICreateEnrouteATCAircraft(const char *szContainerTitle, const char *szTailNumber,
                                                   int iFlightNumber, const char *szFlightPlanPath,
-                                                  double dFlightPlanPosition, WINBOOL bTouchAndGo,
+                                                  double dFlightPlanPosition, BOOL2 bTouchAndGo,
                                                   SIMCONNECT_DATA_REQUEST_ID RequestID)
 {
   if(hSimConnect == NULL || SC_AICreateEnrouteATCAircraft == nullptr)

--- a/src/fs/sc/simconnectapi.h
+++ b/src/fs/sc/simconnectapi.h
@@ -31,6 +31,12 @@ extern "C" {
 #include "fs/sc/simconnectdummy.h"
 #endif
 
+#ifdef WINBOOL                  // care for (possibly outdated) MingW WINBOOL
+#define BOOL2 WINBOOL
+#else
+#define BOOL2 BOOL              // WINBOOL is (/was) BOOL, however Qt might (have) define(d) it (some time ago) too: https://bugreports.qt.io/browse/QTBUG-46463
+#endif
+
 namespace atools {
 namespace win {
 class ActivationContext;
@@ -63,7 +69,7 @@ public:
                               SIMCONNECT_STATE dwState);
   HRESULT AddClientEventToNotificationGroup(SIMCONNECT_NOTIFICATION_GROUP_ID GroupID,
                                             SIMCONNECT_CLIENT_EVENT_ID EventID,
-                                            BOOL bMaskable = FALSE);
+                                            BOOL2 bMaskable = FALSE);
   HRESULT RemoveClientEvent(SIMCONNECT_NOTIFICATION_GROUP_ID GroupID,
                             SIMCONNECT_CLIENT_EVENT_ID EventID);
   HRESULT SetNotificationGroupPriority(SIMCONNECT_NOTIFICATION_GROUP_ID GroupID,
@@ -96,7 +102,7 @@ public:
                                      SIMCONNECT_CLIENT_EVENT_ID DownEventID, DWORD DownValue =
                                        0, SIMCONNECT_CLIENT_EVENT_ID UpEventID =
                                        (SIMCONNECT_CLIENT_EVENT_ID)SIMCONNECT_UNUSED,
-                                     DWORD UpValue = 0, BOOL bMaskable = FALSE);
+                                     DWORD UpValue = 0, BOOL2 bMaskable = FALSE);
   HRESULT SetInputGroupPriority(SIMCONNECT_INPUT_GROUP_ID GroupID,
                                 DWORD uPriority);
   HRESULT RemoveInputEvent(SIMCONNECT_INPUT_GROUP_ID GroupID,
@@ -147,7 +153,7 @@ public:
   HRESULT AICreateEnrouteATCAircraft(const char *szContainerTitle,
                                      const char *szTailNumber, int iFlightNumber,
                                      const char *szFlightPlanPath, double dFlightPlanPosition,
-                                     BOOL bTouchAndGo,
+                                     BOOL2 bTouchAndGo,
                                      SIMCONNECT_DATA_REQUEST_ID RequestID);
   HRESULT AICreateNonATCAircraft(const char *szContainerTitle,
                                  const char *szTailNumber,
@@ -232,7 +238,7 @@ private:
   HRESULT (_stdcall *SC_AddClientEventToNotificationGroup)(HANDLE hSimConnect,
                                                            SIMCONNECT_NOTIFICATION_GROUP_ID GroupID,
                                                            SIMCONNECT_CLIENT_EVENT_ID EventID,
-                                                           BOOL bMaskable) = nullptr;
+                                                           BOOL2 bMaskable) = nullptr;
   HRESULT (_stdcall *SC_RemoveClientEvent)(HANDLE hSimConnect, SIMCONNECT_NOTIFICATION_GROUP_ID GroupID,
                                            SIMCONNECT_CLIENT_EVENT_ID EventID) = nullptr;
   HRESULT (_stdcall *SC_SetNotificationGroupPriority)(HANDLE hSimConnect,
@@ -267,7 +273,7 @@ private:
                                                     const char *szInputDefinition,
                                                     SIMCONNECT_CLIENT_EVENT_ID DownEventID, DWORD DownValue,
                                                     SIMCONNECT_CLIENT_EVENT_ID UpEventID,
-                                                    DWORD UpValue, BOOL bMaskable) = nullptr;
+                                                    DWORD UpValue, BOOL2 bMaskable) = nullptr;
   HRESULT (_stdcall *SC_SetInputGroupPriority)(HANDLE hSimConnect, SIMCONNECT_INPUT_GROUP_ID GroupID,
                                                DWORD uPriority) = nullptr;
   HRESULT (_stdcall *SC_RemoveInputEvent)(HANDLE hSimConnect, SIMCONNECT_INPUT_GROUP_ID GroupID,
@@ -320,7 +326,7 @@ private:
   HRESULT (_stdcall *SC_AICreateEnrouteATCAircraft)(HANDLE hSimConnect, const char *szContainerTitle,
                                                     const char *szTailNumber, int iFlightNumber,
                                                     const char *szFlightPlanPath, double dFlightPlanPosition,
-                                                    BOOL bTouchAndGo,
+                                                    BOOL2 bTouchAndGo,
                                                     SIMCONNECT_DATA_REQUEST_ID RequestID) = nullptr;
   HRESULT (_stdcall *SC_AICreateNonATCAircraft)(HANDLE hSimConnect, const char *szContainerTitle,
                                                 const char *szTailNumber,

--- a/src/fs/sc/simconnectdata.cpp
+++ b/src/fs/sc/simconnectdata.cpp
@@ -21,6 +21,9 @@
 
 #include <QDebug>
 #include <QDataStream>
+#include <QIODevice>
+
+#include <algorithm>
 
 using atools::fs::weather::MetarResult;
 
@@ -137,13 +140,13 @@ int SimConnectData::write(QIODevice *ioDevice)
   if(userValid)
     userAircraft.write(out);
 
-  int numAi = std::min(65535, aiAircraft.size());
+  int numAi = std::min((qsizetype)65535, aiAircraft.size());
   out << static_cast<quint16>(numAi);
 
   for(int i = 0; i < numAi; i++)
     aiAircraft.at(i).write(out);
 
-  int numMetar = std::min(65535, metarResults.size());
+  int numMetar = std::min((qsizetype)65535, metarResults.size());
   out << static_cast<quint16>(numMetar);
 
   for(int i = 0; i < numMetar; i++)

--- a/src/fs/sc/simconnectdummy.cpp
+++ b/src/fs/sc/simconnectdummy.cpp
@@ -21,10 +21,15 @@
 
 #include <QDebug>
 
+#if ! _MSC_VER || __INTEL_COMPILER                      // intel compiler defines _MSC_VER, didn't check whether it supports GCC
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#else
+#pragma warning(push)
+#pragma warning(disable:4100)
+#endif
 
-HRESULT StringCbLengthA(const char *, size_t cbMax, size_t *pcb)
+HRESULT StringCbLengthA_atools(const char *, size_t cbMax, size_t *pcb)
 {
   static HRESULT hr = E_FAIL;
   return hr;
@@ -504,5 +509,11 @@ SIMCONNECTAPI SimConnect_RequestFacilitiesList(HANDLE hSimConnect, SIMCONNECT_FA
 {
   return E_FAIL;
 }
+
+
+
+#if _MSC_VER && ! __INTEL_COMPILER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/src/fs/sc/simconnectdummy.h
+++ b/src/fs/sc/simconnectdummy.h
@@ -57,7 +57,7 @@ typedef LPCSTR LPCTSTR;
 
 #define CALLBACK
 
-HRESULT StringCbLengthA(const char *, size_t cbMax, size_t *pcb);
+HRESULT StringCbLengthA_atools(const char *, size_t cbMax, size_t *pcb);
 
 #else
 #include <float.h>

--- a/src/fs/sc/simconnecthandler.cpp
+++ b/src/fs/sc/simconnecthandler.cpp
@@ -29,11 +29,13 @@
 #include <QThread>
 #include <QSet>
 #include <QCache>
-#include <QLatin1Literal>
+#include <QLatin1String>
 #include <QCoreApplication>
 #include <QDir>
 
+#if ! _MSC_VER || __INTEL_COMPILER                      // intel compiler defines _MSC_VER, didn't check whether it supports GCC
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
 
 using atools::fs::weather::MetarResult;
 
@@ -491,7 +493,7 @@ void SimConnectHandlerPrivate::copyToSimData(const SimDataAircraft& simDataUserA
   if(simDataUserAircraft.userSim > 0)
     aircraft.flags |= atools::fs::sc::IS_USER;
 
-  if(simPaused > 0)
+  if(simPaused)
     aircraft.flags |= atools::fs::sc::SIM_PAUSED;
 }
 
@@ -1079,7 +1081,7 @@ const WeatherRequest& SimConnectHandler::getWeatherRequest() const
 
 QString atools::fs::sc::SimConnectHandler::getName() const
 {
-  return QLatin1Literal("SimConnect");
+  return QLatin1String("SimConnect");
 }
 
 } // namespace sc

--- a/src/fs/sc/simconnectreply.cpp
+++ b/src/fs/sc/simconnectreply.cpp
@@ -20,6 +20,7 @@
 
 #include <QDebug>
 #include <QDataStream>
+#include <QIODevice>
 
 namespace atools {
 namespace fs {

--- a/src/fs/sc/xpconnecthandler.cpp
+++ b/src/fs/sc/xpconnecthandler.cpp
@@ -158,7 +158,7 @@ atools::fs::sc::State XpConnectHandler::getState() const
 
 QString XpConnectHandler::getName() const
 {
-  return QLatin1Literal("XpConnect");
+  return QLatin1String("XpConnect");
 }
 
 void XpConnectHandler::disconnect()

--- a/src/fs/sc/xpconnecthandler.h
+++ b/src/fs/sc/xpconnecthandler.h
@@ -22,6 +22,7 @@
 
 #include <QSharedMemory>
 #include <functional>
+#include <QLatin1String>
 
 namespace atools {
 namespace fs {
@@ -29,7 +30,7 @@ namespace sc {
 
 /* Defaul size of the shared memory segment */
 static const int SHARED_MEMORY_SIZE = 8196;
-static const QLatin1Literal SHARED_MEMORY_KEY("LittleXpconnect");
+static const QLatin1String SHARED_MEMORY_KEY("LittleXpconnect");
 
 /*
  * Reads data from a callback function into SimConnectData.

--- a/src/fs/scenery/contentxml.cpp
+++ b/src/fs/scenery/contentxml.cpp
@@ -64,7 +64,7 @@ void ContentXml::read(const QString& filename)
 
     while(xmlStream.readNextStartElement())
     {
-      if(reader.name() == "Package")
+      if(reader.name().toString() == QString("Package"))
       {
         QString name = reader.attributes().value("name").toString();
         QString activeStr = reader.attributes().value("active").toString().simplified().toLower();
@@ -109,12 +109,12 @@ QDebug operator<<(QDebug out, const ContentXml& cfg)
 {
   QDebugStateSaver saver(out);
 
-  out.nospace() << "ContentXml[" << endl;
+  out.nospace() << "ContentXml[" << Qt::endl;
 
   for(const SceneryArea& area : cfg.areaEntries)
-    out.nospace().noquote() << area << endl;
+    out.nospace().noquote() << area << Qt::endl;
 
-  out.nospace().noquote() << endl << "]";
+  out.nospace().noquote() << Qt::endl << "]";
   return out;
 }
 

--- a/src/fs/scenery/materiallib.cpp
+++ b/src/fs/scenery/materiallib.cpp
@@ -78,11 +78,11 @@ void MaterialLib::read(const QString& filename)
 
     while(xmlStream.readNextStartElement())
     {
-      if(reader.name() == "Material")
+      if(reader.name().toString() == QString("Material"))
       {
         QString surface = reader.attributes().value("SurfaceType").toString();
         if(surface != "UNDEFINED")
-          surfaceMap.insert(reader.attributes().value("Guid").toString(), surface);
+          surfaceMap.insert(QUuid::fromString(reader.attributes().value("Guid").toString()), surface);
 
         // Read only attributes
         xmlStream.skipCurrentElement();

--- a/src/fs/scenery/scenerycfg.cpp
+++ b/src/fs/scenery/scenerycfg.cpp
@@ -153,12 +153,12 @@ QDebug operator<<(QDebug out, const SceneryCfg& cfg)
   out.nospace() << "SceneryCfg["
                 << "title " << cfg.title
                 << ", description " << cfg.description
-                << ", cleanOnExit " << cfg.cleanOnExit << endl;
+                << ", cleanOnExit " << cfg.cleanOnExit << Qt::endl;
 
   for(const SceneryArea& area : cfg.areaEntries)
-    out.nospace().noquote() << area << endl;
+    out.nospace().noquote() << area << Qt::endl;
 
-  out.nospace().noquote() << endl << "]";
+  out.nospace().noquote() << Qt::endl << "]";
   return out;
 }
 

--- a/src/fs/userdata/datamanagerbase.cpp
+++ b/src/fs/userdata/datamanagerbase.cpp
@@ -119,7 +119,7 @@ void DataManagerBase::backup()
     if(file.open(QIODevice::WriteOnly | QIODevice::Text))
     {
       QTextStream out(&file);
-      out.setCodec("UTF-8");
+      out.setEncoding(QStringConverter::Utf8);
       SqlQuery query("select * from " + tableName, db);
       SqlExport sqlExport;
       sqlExport.printResultSet(query, out);

--- a/src/fs/userdata/logdatamanager.cpp
+++ b/src/fs/userdata/logdatamanager.cpp
@@ -166,7 +166,7 @@ int LogdataManager::importCsv(const QString& filepath)
     atools::util::CsvReader reader;
 
     QTextStream stream(&file);
-    stream.setCodec("UTF-8");
+    stream.setEncoding(QStringConverter::Utf8);
 
     int lineNum = 0;
     while(!stream.atEnd())
@@ -367,7 +367,7 @@ int LogdataManager::importXplane(const QString& filepath,
     QString filename = QFileInfo(filepath).fileName();
 
     QTextStream stream(&file);
-    stream.setCodec("UTF-8");
+    stream.setEncoding(QStringConverter::Utf8);
 
     int lineNum = 0;
     while(!stream.atEnd())
@@ -508,12 +508,12 @@ int LogdataManager::exportCsv(const QString& filepath, const QVector<int>& ids, 
     QueryWrapper query(util.buildSelectStatement(tableName, columns), db, ids, idColumnName);
 
     QTextStream stream(&file);
-    stream.setCodec("UTF-8");
+    stream.setEncoding(QStringConverter::Utf8);
     stream.setRealNumberNotation(QTextStream::FixedNotation);
 
     if(!endsWithEol && append)
       // Add needed linefeed for append
-      stream << endl;
+      stream << Qt::endl;
 
     SqlExport sqlExport;
     sqlExport.setEndline(false);
@@ -537,12 +537,12 @@ int LogdataManager::exportCsv(const QString& filepath, const QVector<int>& ids, 
       {
         // Write header
         first = false;
-        stream << sqlExport.getResultSetHeader(query.q.record()) << endl;
+        stream << sqlExport.getResultSetHeader(query.q.record()) << Qt::endl;
       }
       SqlRecord record = query.q.record();
 
       // Write row
-      stream << sqlExport.getResultSetRow(record) << endl;
+      stream << sqlExport.getResultSetRow(record) << Qt::endl;
       numExported++;
     }
 

--- a/src/fs/userdata/userdatamanager.cpp
+++ b/src/fs/userdata/userdatamanager.cpp
@@ -408,7 +408,7 @@ int UserdataManager::exportCsv(const QString& filepath, const QVector<int>& ids,
 
     if(!endsWithEol && (flags & APPEND))
       // Add needed linefeed for append
-      stream << endl;
+      stream << Qt::endl;
 
     bool first = true;
 
@@ -419,7 +419,7 @@ int UserdataManager::exportCsv(const QString& filepath, const QVector<int>& ids,
       {
         // Write header
         first = false;
-        stream << sqlExport.getResultSetHeader(query.q.record()) << endl;
+        stream << sqlExport.getResultSetHeader(query.q.record()) << Qt::endl;
       }
       SqlRecord record = query.q.record();
 
@@ -432,7 +432,7 @@ int UserdataManager::exportCsv(const QString& filepath, const QVector<int>& ids,
       record.setValue("Magnetic Declination", static_cast<double>(magvar));
 
       // Write row
-      stream << sqlExport.getResultSetRow(record) << endl;
+      stream << sqlExport.getResultSetRow(record) << Qt::endl;
       numExported++;
     }
 
@@ -468,7 +468,7 @@ int UserdataManager::exportXplane(const QString& filepath, const QVector<int>& i
           QString line = inStream.readLine();
           if(line.simplified() == "99")
             break;
-          tempOutStream << line << endl;
+          tempOutStream << line << Qt::endl;
         }
 
         inFile.close();
@@ -503,11 +503,11 @@ int UserdataManager::exportXplane(const QString& filepath, const QVector<int>& i
     if(!(flags & APPEND))
     {
       // Add file header
-      stream << "I" << endl << "1100 Version - "
+      stream << "I" << Qt::endl << "1100 Version - "
              << "data cycle " << QLocale(QLocale::C).toString(QDateTime::currentDateTime(), "yyMM") << ", "
              << "build " << QLocale(QLocale::C).toString(QDateTime::currentDateTime(), "yyyyMMdd") << ", "
              << "metadata FixXP1100. "
-             << atools::programFileInfoNoDate() << "." << endl << endl;
+             << atools::programFileInfoNoDate() << "." << Qt::endl << Qt::endl;
     }
 
     QueryWrapper query(
@@ -526,11 +526,11 @@ int UserdataManager::exportXplane(const QString& filepath, const QVector<int>& i
              << " " << atools::fs::util::adjustIdent(query.q.valueStr("ident"), 5, query.q.valueInt(idColumnName))
              << " " << "ENRT" // Ignore airport here
              << " " << (region.isEmpty() ? "ZZ" : atools::fs::util::adjustRegion(region))
-             << endl;
+             << Qt::endl;
       numExported++;
     }
 
-    stream << "99" << endl;
+    stream << "99" << Qt::endl;
 
     file.close();
   }
@@ -554,7 +554,7 @@ int UserdataManager::exportGarmin(const QString& filepath, const QVector<int>& i
     stream.setCodec("UTF-8");
 
     if(!endsWithEol && (flags & APPEND))
-      stream << endl;
+      stream << Qt::endl;
 
     QueryWrapper query("select " + idColumnName + ", ident, name,  laty, lonx from " + tableName, db, ids,
                        idColumnName);
@@ -572,7 +572,7 @@ int UserdataManager::exportGarmin(const QString& filepath, const QVector<int>& i
              << QString::number(query.q.valueDouble("laty"), 'f', 8)
              << ","
              << QString::number(query.q.valueDouble("lonx"), 'f', 8)
-             << endl;
+             << Qt::endl;
       numExported++;
     }
 

--- a/src/fs/weather/metarindex.cpp
+++ b/src/fs/weather/metarindex.cpp
@@ -251,13 +251,13 @@ int MetarIndex::readFlat(QTextStream& stream, const QString& fileOrUrl, bool mer
           dateStr.prepend('0');
 
         bool ok;
-        int day = dateStr.midRef(0, 2).toInt(&ok);
+        int day = dateStr.mid(0, 2).toInt(&ok);
         if((!ok || day < 1 || day > 31) && verbose)
           qWarning() << Q_FUNC_INFO << "Cannot read day in METAR" << line;
-        int hour = dateStr.midRef(2, 2).toInt(&ok);
+        int hour = dateStr.mid(2, 2).toInt(&ok);
         if((!ok || hour < 0 || hour > 23) && verbose)
           qWarning() << Q_FUNC_INFO << "Cannot read hour in METAR" << line;
-        int minute = dateStr.midRef(4, 2).toInt(&ok);
+        int minute = dateStr.mid(4, 2).toInt(&ok);
         if((!ok || minute < 0 || minute > 60) && verbose)
           qWarning() << Q_FUNC_INFO << "Cannot read minute in METAR" << line;
 

--- a/src/fs/weather/metarparser.cpp
+++ b/src/fs/weather/metarparser.cpp
@@ -47,6 +47,7 @@
 #include <iostream>
 #include <QDateTime>
 #include <QDebug>
+#include <QLatin1String>
 
 // #define QT_NO_CAST_FROM_BYTEARRAY
 // #define QT_NO_CAST_TO_ASCII
@@ -1577,7 +1578,7 @@ bool MetarParser::scanRunwayReport()
       return false;
 
     if(i == 0)
-      r.depth = 0.0005; // < 1 mm deep (let's say 0.5 :-)
+      r.depth = 0.0005f; // < 1 mm deep (let's say 0.5 :-)
     else if(i > 0 && i <= 90)
       r.depth = i / 1000.0; // i mm deep
     else if(i >= 92 && i <= 98)
@@ -1846,19 +1847,19 @@ QString MetarCloud::getCoverageString() const
 
 MetarCloud::Coverage MetarCloud::getCoverage(const QString& coverage)
 {
-  if(coverage == QLatin1Literal("clear"))
+  if(coverage == QLatin1String("clear"))
     return COVERAGE_CLEAR;
 
-  if(coverage == QLatin1Literal("few"))
+  if(coverage == QLatin1String("few"))
     return COVERAGE_FEW;
 
-  if(coverage == QLatin1Literal("scattered"))
+  if(coverage == QLatin1String("scattered"))
     return COVERAGE_SCATTERED;
 
-  if(coverage == QLatin1Literal("broken"))
+  if(coverage == QLatin1String("broken"))
     return COVERAGE_BROKEN;
 
-  if(coverage == QLatin1Literal("overcast"))
+  if(coverage == QLatin1String("overcast"))
     return COVERAGE_OVERCAST;
 
   return COVERAGE_NIL;

--- a/src/fs/weather/metarparser.h
+++ b/src/fs/weather/metarparser.h
@@ -454,7 +454,7 @@ public:
 
   inline QVector<MetarCloud> getClouds() const
   {
-    return QVector<MetarCloud>::fromStdVector(_clouds);
+    return QVector<MetarCloud>(_clouds.begin(), _clouds.end());
   }
 
   inline QHash<QString, MetarRunway> getRunways() const;
@@ -463,8 +463,7 @@ public:
 
   inline QVector<struct Weather> getWeather2() const
   {
-    return QVector<struct Weather>::fromStdVector(_weather2);
-
+    return QVector<struct Weather>(_weather2.begin(), _weather2.end());
   }
 
   bool isValid() const

--- a/src/fs/weather/xpweatherreader.cpp
+++ b/src/fs/weather/xpweatherreader.cpp
@@ -85,7 +85,7 @@ bool XpWeatherReader::read()
   {
     qDebug() << Q_FUNC_INFO << weatherFile;
     QTextStream stream(&file);
-    stream.setCodec("UTF-8");
+    stream.setEncoding(QStringConverter::Utf8);
     metarIndex->read(stream, weatherFile, false /* merge */);
     file.close();
   }

--- a/src/fs/xp/xpwriter.h
+++ b/src/fs/xp/xpwriter.h
@@ -23,8 +23,6 @@
 
 #include <QStringList>
 
-class QStringList;
-
 namespace atools {
 namespace sql {
 class SqlDatabase;

--- a/src/geo/calculations.cpp
+++ b/src/geo/calculations.cpp
@@ -745,10 +745,10 @@ bool crossesAntiMeridian(float lonx1, float lonx2)
 
 void registerMetaTypes()
 {
-  qRegisterMetaTypeStreamOperators<atools::geo::Pos>();
-  qRegisterMetaTypeStreamOperators<atools::geo::Rect>();
-  qRegisterMetaTypeStreamOperators<atools::geo::Line>();
-  qRegisterMetaTypeStreamOperators<atools::geo::LineString>();
+  qRegisterMetaType<atools::geo::Pos>();
+  qRegisterMetaType<atools::geo::Rect>();
+  qRegisterMetaType<atools::geo::Line>();
+  qRegisterMetaType<atools::geo::LineString>();
 }
 
 bool isWestCourse(float lonx1, float lonx2)

--- a/src/geo/linestring.cpp
+++ b/src/geo/linestring.cpp
@@ -32,18 +32,12 @@ LineString::LineString()
 }
 
 LineString::LineString(const std::initializer_list<Pos>& list)
-  : QVector(list)
+  : QList(list)
 {
 }
 
 LineString::LineString(const QVector<Pos>& list)
-  : QVector(list)
-{
-
-}
-
-LineString::LineString(const QList<Pos>& list)
-  : QVector(list.toVector())
+  : QList(list)
 {
 
 }
@@ -62,7 +56,7 @@ LineString::LineString(const std::initializer_list<float>& coordinatePairs)
 }
 
 LineString::LineString(const Pos& pos)
-  : QVector(
+  : QList(
     {
       pos
     })
@@ -71,7 +65,7 @@ LineString::LineString(const Pos& pos)
 }
 
 LineString::LineString(const Pos& pos1, const Pos& pos2)
-  : QVector(
+  : QList(
     {
       pos1, pos2
     })

--- a/src/geo/linestring.h
+++ b/src/geo/linestring.h
@@ -37,7 +37,6 @@ class LineString :
 public:
   LineString();
   explicit LineString(const std::initializer_list<atools::geo::Pos>& list);
-  explicit LineString(const QVector<atools::geo::Pos>& list);
   explicit LineString(const QList<atools::geo::Pos>& list);
   explicit LineString(const std::initializer_list<float>& coordinatePairs);
   explicit LineString(const atools::geo::Pos& pos);
@@ -51,34 +50,34 @@ public:
                       const atools::geo::Pos& end, bool clockwise, int numSegments);
 
   LineString(const atools::geo::LineString& other)
-    : QVector(other)
+    : QList(other)
   {
   }
 
   atools::geo::LineString& operator=(const atools::geo::LineString& other)
   {
-    QVector::operator=(other);
+    QList::operator=(other);
     return *this;
   }
 
   void append(const atools::geo::Pos& pos)
   {
-    QVector::append(pos);
+    QList::append(pos);
   }
 
   void append(const atools::geo::LineString& linestring)
   {
-    QVector::append(linestring);
+    QList::append(linestring);
   }
 
   void append(float longitudeX, float latitudeY, float alt = 0.f)
   {
-    QVector::append(Pos(longitudeX, latitudeY, alt));
+    QList::append(Pos(longitudeX, latitudeY, alt));
   }
 
   void append(double longitudeX, double latitudeY, double alt = 0.f)
   {
-    QVector::append(Pos(longitudeX, latitudeY, alt));
+    QList::append(Pos(longitudeX, latitudeY, alt));
   }
 
   LineString reversed();
@@ -129,19 +128,19 @@ public:
    * (or all remaining elements if there are less than length elements) are included.*/
   atools::geo::LineString mid(int pos, int len = -1) const
   {
-    return atools::geo::LineString(QVector::mid(pos, len));
+    return atools::geo::LineString(QList::mid(pos, len));
   }
 
   /* Returns a string with len number of coordinates from the beginning of the list */
   atools::geo::LineString left(int len) const
   {
-    return atools::geo::LineString(QVector::mid(0, len));
+    return atools::geo::LineString(QList::mid(0, len));
   }
 
   /* Returns a string with len number of coordinates from the end of the list */
   atools::geo::LineString right(int len) const
   {
-    return atools::geo::LineString(QVector::mid(size() - len));
+    return atools::geo::LineString(QList::mid(size() - len));
   }
 
   /* Calculate Length of the line string in meter */

--- a/src/geo/nanoflann.h
+++ b/src/geo/nanoflann.h
@@ -1198,7 +1198,7 @@ public:
       return;
     computeBoundingBox(BaseClassRef::root_bbox);
     BaseClassRef::root_node =
-        this->divideTree(*this, 0, BaseClassRef::m_size,
+        this->divideTree(*this, 0, (IndexType)BaseClassRef::m_size,
                          BaseClassRef::root_bbox); // construct the tree
   }
 
@@ -1311,7 +1311,7 @@ public:
     if (BaseClassRef::vind.size() != BaseClassRef::m_size)
       BaseClassRef::vind.resize(BaseClassRef::m_size);
     for (size_t i = 0; i < BaseClassRef::m_size; i++)
-      BaseClassRef::vind[i] = i;
+      BaseClassRef::vind[i] = (IndexType)i;
   }
 
   void computeBoundingBox(BoundingBox &bbox) {

--- a/src/geo/point3d.cpp
+++ b/src/geo/point3d.cpp
@@ -25,7 +25,7 @@ namespace geo {
 QDebug operator<<(QDebug out, const Point3D& pt)
 {
   QDebugStateSaver saver(out);
-  out.nospace().noquote() << fixed << qSetRealNumberPrecision(1)
+  out.nospace().noquote() << Qt::fixed << qSetRealNumberPrecision(1)
                           << "Point3D(x " << pt.x << ", y " << pt.y << ", z " << pt.z
                           << ", valid " << pt.isValid() << ")";
   return out;

--- a/src/geo/pos.h
+++ b/src/geo/pos.h
@@ -19,6 +19,7 @@
 #define ATOOLS_GEO_POSITION_H
 
 #include <QDebug>
+#include <QVariant>
 
 namespace atools {
 namespace geo {

--- a/src/grib/windquery.cpp
+++ b/src/grib/windquery.cpp
@@ -398,10 +398,10 @@ QString WindQuery::getDebug(const geo::Pos& pos) const
 {
   QString retval;
   QTextStream out(&retval);
-  out.setCodec("UTF-8");
+  out.setEncoding(QStringConverter::Utf8);
   out.setRealNumberPrecision(2);
   out.setRealNumberNotation(QTextStream::FixedNotation);
-  out << "=================" << endl;
+  out << "=================" << Qt::endl;
   for(int altitude : windLayers.keys())
   {
     WindAltLayer layer = windLayers.value(altitude);
@@ -409,11 +409,11 @@ QString WindQuery::getDebug(const geo::Pos& pos) const
     WindData wind = windForLayer(layer, grid);
 
     out << "altitude " << altitude << " surface " << layer.surface
-        << " grid x " << grid.x() << " y " << grid.y() << endl;
+        << " grid x " << grid.x() << " y " << grid.y() << Qt::endl;
     out << "wind u " << wind.u << " v " << wind.v << " kts "
         << " dir " << windDirectionFromUV(wind.u, wind.v) << " deg T"
-        << " speed " << windSpeedFromUV(wind.u, wind.v) << " kts" << endl;
-    out << "-----------" << endl;
+        << " speed " << windSpeedFromUV(wind.u, wind.v) << " kts" << Qt::endl;
+    out << "-----------" << Qt::endl;
   }
   return retval;
 }
@@ -529,19 +529,19 @@ void WindQuery::layersByAlt(WindAltLayer& lower, WindAltLayer& upper, float alti
     {
       if(atools::almostEqual(it->altitude, atools::roundToInt(altitude), ALTITUDE_EPSILON))
         // Layer is at requested altitude - no need to interpolate
-        lower = upper = *it;
+        lower = upper = it.value();
       else if(it == windLayers.begin())
       {
         // First layer - add a zero wind layer for interpolation between layer and ground
-        upper = *it;
+        upper = it.value();
 
         lower.altitude = 0.f;
         lower.winds.fill(EMPTY_WIND_DATA, 360 * 181);
       }
       else
       {
-        lower = *(it - 1);
-        upper = *it;
+        lower = (--it).value();
+        upper = (++it).value();
       }
     }
     else

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -97,7 +97,7 @@ QString Application::generalErrorMessage()
 
 void Application::setTooltipsDisabled(const QList<QObject *>& exceptions)
 {
-  tooltipExceptions = exceptions.toSet();
+  tooltipExceptions = QSet(exceptions.begin(), exceptions.end());
   tooltipsDisabled = true;
 }
 

--- a/src/gui/dockwidgethandler.cpp
+++ b/src/gui/dockwidgethandler.cpp
@@ -31,6 +31,7 @@
 #include <QMessageBox>
 #include <QApplication>
 #include <QScreen>
+#include <QFile>
 
 namespace atools {
 namespace gui {
@@ -821,11 +822,8 @@ bool DockWidgetHandler::isWindowLayoutFile(const QString& filename)
 
 void DockWidgetHandler::registerMetaTypes()
 {
-  qRegisterMetaTypeStreamOperators<atools::gui::MainWindowState>();
+  qRegisterMetaType<atools::gui::MainWindowState>();
 }
 
 } // namespace gui
 } // namespace atools
-
-// Enable use in QVariant
-Q_DECLARE_METATYPE(atools::gui::MainWindowState);

--- a/src/gui/dockwidgethandler.h
+++ b/src/gui/dockwidgethandler.h
@@ -164,7 +164,7 @@ public:
     return delayedFullscreen;
   }
 
-  /* Calls qRegisterMetaTypeStreamOperators for needed classes. */
+  /* Calls qRegisterMetaType for needed classes. */
   static void registerMetaTypes();
 
 private:
@@ -216,5 +216,8 @@ private:
 
 } // namespace gui
 } // namespace atools
+
+// Enable use in QVariant
+Q_DECLARE_METATYPE(atools::gui::MainWindowState);
 
 #endif // ATOOLS_DOCKWIDGETHANDLER_H

--- a/src/gui/mapposhistory.cpp
+++ b/src/gui/mapposhistory.cpp
@@ -231,8 +231,8 @@ void MapPosHistory::clear()
 
 void MapPosHistory::registerMetaTypes()
 {
-  qRegisterMetaTypeStreamOperators<atools::gui::MapPosHistoryEntry>();
-  qRegisterMetaTypeStreamOperators<QList<atools::gui::MapPosHistoryEntry> >();
+  qRegisterMetaType<atools::gui::MapPosHistoryEntry>();
+  qRegisterMetaType<QList<atools::gui::MapPosHistoryEntry> >();
 }
 
 } // namespace gui

--- a/src/gui/signalblocker.h
+++ b/src/gui/signalblocker.h
@@ -38,28 +38,12 @@ public:
   template<typename TYPE>
   void add(QList<TYPE *> objectList);
 
-  template<typename TYPE>
-  void add(QVector<TYPE *> objectList);
-
 private:
   QList<QObject *> objects;
 };
 
 template<typename TYPE>
 void SignalBlocker::add(QList<TYPE *> objectList)
-{
-  for(TYPE *object : objectList)
-  {
-    if(object != nullptr)
-    {
-      objects.append(object);
-      object->blockSignals(true);
-    }
-  }
-}
-
-template<typename TYPE>
-void SignalBlocker::add(QVector<TYPE *> objectList)
 {
   for(TYPE *object : objectList)
   {

--- a/src/gui/translator.cpp
+++ b/src/gui/translator.cpp
@@ -191,10 +191,10 @@ bool Translator::loadAndInstall(const QString& name, const QString& dir, const Q
   QLocale locale;
   if(language.isEmpty())
     // Use only one language here since the translation API will try to load second and third languages
-    locale = QLocale().uiLanguages().isEmpty() ? "en" : QLocale().uiLanguages().at(0);
+    locale = QLocale(QLocale().uiLanguages().isEmpty() ? "en" : QLocale().uiLanguages().at(0));
   else
     // Override system language for translations only
-    locale = language;
+    locale = QLocale(language);
 
   QTranslator *t = new QTranslator();
   if(!t->load(locale, name, "_", dir))

--- a/src/httpserver/httpconnectionhandlerpool.cpp
+++ b/src/httpserver/httpconnectionhandlerpool.cpp
@@ -128,7 +128,7 @@ void HttpConnectionHandlerPool::loadSslConfig()
     sslConfiguration->setLocalCertificate(certificate);
     sslConfiguration->setPrivateKey(sslKey);
     sslConfiguration->setPeerVerifyMode(QSslSocket::VerifyNone);
-    sslConfiguration->setProtocol(QSsl::TlsV1SslV3);
+    sslConfiguration->setProtocol(QSsl::TlsV1_3);
 
     qDebug("HttpConnectionHandlerPool: SSL settings loaded");
          #endif

--- a/src/io/abstractinireader.cpp
+++ b/src/io/abstractinireader.cpp
@@ -119,7 +119,9 @@ void AbstractIniReader::read(const QString& iniFilename)
     QTextStream sceneryCfg(&sceneryCfgFile);
 
     if(!codec.isEmpty())
-      sceneryCfg.setCodec(codec.toLatin1().constData());
+      sceneryCfg.setEncoding(QStringConverter::Latin1);
+
+    // TODO: use codec meaningfully
 
     onStartDocument(filepath);
 

--- a/src/io/binarystream.cpp
+++ b/src/io/binarystream.cpp
@@ -217,7 +217,7 @@ void BinaryStream::checkStream(const QString& what) const
   {
     QString msg = QString("%1 for file \"%2\" failed. Reason %3").arg(what).arg(getFilename()).arg(is->status());
 
-    qWarning() << msg << "Position" << hex << "0x" << is->device()->pos() << dec << is->device()->pos();
+    qWarning() << msg << "Position" << Qt::hex << "0x" << is->device()->pos() << Qt::dec << is->device()->pos();
     throw Exception(msg);
   }
 }

--- a/src/io/binarystream.h
+++ b/src/io/binarystream.h
@@ -19,6 +19,8 @@
 #define ATOOLS_IO_BINARYSTREAM_H
 
 #include <QDataStream>
+#include <QChar>
+#include <QUuid>
 
 class QFile;
 

--- a/src/io/binaryutil.h
+++ b/src/io/binaryutil.h
@@ -20,6 +20,7 @@
 
 #include <QDataStream>
 #include <QVector>
+#include <QIODevice>
 
 namespace atools {
 namespace io {
@@ -29,7 +30,7 @@ namespace io {
 template<typename TYPE, typename SIZETYPE>
 QVector<TYPE> readVector(QByteArray bytes)
 {
-  QDataStream out(&bytes, QIODevice::ReadOnly);
+  QDataStream out(&bytes, QIODeviceBase::ReadOnly);
   out.setVersion(QDataStream::Qt_5_5);
   out.setFloatingPointPrecision(QDataStream::SinglePrecision);
 

--- a/src/io/fileroller.h
+++ b/src/io/fileroller.h
@@ -21,7 +21,6 @@
 #include <QString>
 
 class QString;
-class QStringList;
 
 namespace atools {
 namespace io {

--- a/src/logging/loggingconfig.cpp
+++ b/src/logging/loggingconfig.cpp
@@ -141,7 +141,7 @@ QStringList LoggingConfig::getLogFiles()
   collectFileNames(filenames, criticalStreamsCat);
   collectFileNames(filenames, fatalStreamsCat);
   collectFileNames(filenames, emptyStreamsCat);
-  return filenames.toList();
+  return QList<QString>(filenames.begin(), filenames.end());
 }
 
 void LoggingConfig::collectFileNames(QSet<QString>& filenames, const ChannelMap& channelMap)
@@ -191,7 +191,7 @@ void LoggingConfig::checkStreamSize(Channel *channel)
       // Put log file into stream
       channel->file = file;
       channel->stream->setDevice(channel->file);
-      channel->stream->setCodec("UTF-8");
+      channel->stream->setEncoding(QStringConverter::Utf8);
       channel->stream->setLocale(QLocale::C);
     }
   }
@@ -339,14 +339,14 @@ void LoggingConfig::readChannels(QSettings *settings, QHash<QString, Channel *>&
     {
       QTextStream *io = new QTextStream(stdout);
       // Most terminals can deal with utf-8
-      io->setCodec("UTF-8");
+      io->setEncoding(QStringConverter::Utf8);
       channelMap.insert(key, new Channel({io, nullptr}));
     }
     else if(channelName == "stderr")
     {
       QTextStream *err = new QTextStream(stderr);
       // Most terminals can deal with utf-8
-      err->setCodec("UTF-8");
+      err->setEncoding(QStringConverter::Utf8);
       channelMap.insert(key, new Channel({err, nullptr}));
     }
     else
@@ -379,7 +379,7 @@ void LoggingConfig::readChannels(QSettings *settings, QHash<QString, Channel *>&
       if(file->open(mode))
       {
         QTextStream *stream = new QTextStream(file);
-        stream->setCodec("UTF-8");
+        stream->setEncoding(QStringConverter::Utf8);
         stream->setLocale(QLocale::C);
         channelMap.insert(key, new Channel({stream, file}));
       }
@@ -394,7 +394,7 @@ void LoggingConfig::readLevels(QSettings *settings, QHash<QString, Channel *>& c
   for(QString levelName : settings->allKeys())
   {
     // Split the "level.channel" string
-    QStringList levelList = levelName.split(".", QString::SkipEmptyParts);
+    QStringList levelList = levelName.split(".", Qt::SkipEmptyParts);
     QString level = levelList.at(0);
 
     // Use default if category is not given

--- a/src/logging/logginghandler.cpp
+++ b/src/logging/logginghandler.cpp
@@ -22,6 +22,7 @@
 #include <QDir>
 #include <QApplication>
 #include <QThread>
+#include <QLatin1String>
 
 namespace atools {
 namespace logging {
@@ -136,7 +137,7 @@ void LoggingHandler::logToCatChannels(internal::ChannelMap& streamListCat,
   {
     for(Channel *channel : streamList)
     {
-      (*channel->stream) << message << endl << flush;
+      (*channel->stream) << message << Qt::endl << Qt::flush;
       instance->logConfig->checkStreamSize(channel);
     }
   }
@@ -144,7 +145,7 @@ void LoggingHandler::logToCatChannels(internal::ChannelMap& streamListCat,
   {
     for(Channel *channel : streamListCat[category])
     {
-      (*channel->stream) << message << endl << flush;
+      (*channel->stream) << message << Qt::endl << Qt::flush;
       instance->logConfig->checkStreamSize(channel);
     }
   }
@@ -185,7 +186,7 @@ void LoggingHandler::checkAbortType(QtMsgType type, const QMessageLogContext& co
 
 void LoggingHandler::messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
-  static const QLatin1Literal DEFAULT("default");
+  static const QLatin1String DEFAULT("default");
 
   if(logFunc != nullptr)
     logFunc(type, context, msg);
@@ -204,12 +205,12 @@ void LoggingHandler::messageHandler(QtMsgType type, const QMessageLogContext& co
 
 void LoggingHandler::messageHandlerNarrow(QtMsgType type, const QMessageLogContext& context, const QString& msg)
 {
-  static const QLatin1Literal DOUBLE_COLON("::");
-  static const QLatin1Literal VOID("void ");
-  static const QLatin1Literal STATIC_VOID("static void ");
-  static const QLatin1Literal VIRTUAL_VOID("virtual void ");
-  static const QLatin1Literal VIRTUAL("virtual ");
-  static const QLatin1Literal DEFAULT("default");
+  static const QLatin1String DOUBLE_COLON("::");
+  static const QLatin1String VOID("void ");
+  static const QLatin1String STATIC_VOID("static void ");
+  static const QLatin1String VIRTUAL_VOID("virtual void ");
+  static const QLatin1String VIRTUAL("virtual ");
+  static const QLatin1String DEFAULT("default");
 
   QString message = msg;
   QString function(context.function);

--- a/src/logging/logginghandler.h
+++ b/src/logging/logginghandler.h
@@ -27,7 +27,6 @@
 
 class QTextStream;
 class QFile;
-class QStringList;
 class QSettings;
 
 namespace atools {

--- a/src/logging/loggingutil.cpp
+++ b/src/logging/loggingutil.cpp
@@ -62,12 +62,6 @@ void LoggingUtil::logSystemInformation()
           << "version" << QSysInfo::productVersion();
 
   qInfo() << "Qt version" << QT_VERSION_STR;
-
-  if(QSysInfo::windowsVersion() != QSysInfo::WV_None)
-    qInfo() << "Windows version" << QSysInfo::windowsVersion();
-
-  if(QSysInfo::macVersion() != QSysInfo::MV_None)
-    qInfo() << "Mac version" << QSysInfo::macVersion();
 }
 
 void LoggingUtil::logStandardPaths()
@@ -81,7 +75,6 @@ void LoggingUtil::logStandardPaths()
   qInfo() << "PicturesLocation" << QStandardPaths::standardLocations(QStandardPaths::PicturesLocation);
   qInfo() << "TempLocation" << QStandardPaths::standardLocations(QStandardPaths::TempLocation);
   qInfo() << "HomeLocation" << QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
-  qInfo() << "DataLocation" << QStandardPaths::standardLocations(QStandardPaths::DataLocation);
   qInfo() << "CacheLocation" << QStandardPaths::standardLocations(QStandardPaths::CacheLocation);
   qInfo() << "GenericDataLocation" << QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
   qInfo() << "RuntimeLocation" << QStandardPaths::standardLocations(QStandardPaths::RuntimeLocation);

--- a/src/routing/routenetworkloader.cpp
+++ b/src/routing/routenetworkloader.cpp
@@ -36,13 +36,13 @@ using atools::geo::Point3D;
 // Calculate hash for airway name for quick comparison in routing algorithm
 inline quint32 airwayHash(const QString& name)
 {
-  return qHash(name) + 1; // Avoid null
+  return (quint32)qHash(name) + 1; // Avoid null
 }
 
 // Calculate hash for track name and type for quick comparison in routing algorithm
 inline quint32 trackHash(const QString& name, const QString& type)
 {
-  return (qHash(name) ^ (qHash(type) << 8) ^ 0x55555555) + 1; // Avoid null and add pattern to difference for airway
+  return (quint32)(qHash(name) ^ (qHash(type) << 8) ^ 0x55555555) + 1; // Avoid null and add pattern to difference for airway
 }
 
 namespace atools {

--- a/src/routing/routenetworktypes.h
+++ b/src/routing/routenetworktypes.h
@@ -273,7 +273,7 @@ struct Node
   /* Set connections using QFlags wrapper */
   void setConnections(atools::routing::NodeConnections connections)
   {
-    con = static_cast<NodeConnection>(connections.operator unsigned int());
+    con = static_cast<NodeConnection>(connections.operator int());
   }
 
   /* Add flag to connections */

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -67,7 +67,8 @@ void Settings::clearAndShutdown()
   syncSettings();
 
   // Create a backup
-  QFileInfo file = getFilename();
+  QString filename = getFilename();
+  QFileInfo file(filename);
   QString newFile = file.path() + QDir::separator() + file.baseName() +
                     "_" + QDateTime::currentDateTime().toString("yyyyMMdd-HHmmss") + ".ini";
 

--- a/src/sql/sqlquery.h
+++ b/src/sql/sqlquery.h
@@ -126,12 +126,12 @@ public:
     return value(name).toDateTime();
   }
 
-  int valueBool(int i) const
+  bool valueBool(int i) const
   {
     return value(i).toBool();
   }
 
-  int valueBool(const QString& name) const
+  bool valueBool(const QString& name) const
   {
     return value(name).toBool();
   }
@@ -167,7 +167,7 @@ public:
     return hasField(name) ? valueDateTime(name) : defaultValue;
   }
 
-  int valueBool(const QString& name, bool defaultValue) const
+  bool valueBool(const QString& name, bool defaultValue) const
   {
     return hasField(name) ? valueBool(name) : defaultValue;
   }
@@ -184,6 +184,8 @@ public:
   void clear();
 
   /* Nullifies all bound values */
+  // assume intention is exactly that, eg in order to clear possible remnants
+  // TODO: is it relevant to call it After an exec?
   void clearBoundValues();
 
   void exec();
@@ -209,7 +211,6 @@ public:
   QVariant boundValue(const QString& placeholder, bool ignoreInvalid = false) const;
   QVariant boundValue(int pos, bool ignoreInvalid = false) const;
 
-  QMap<QString, QVariant> boundValues() const;
   QString executedQuery() const;
   QVariant lastInsertId() const;
   void finish();
@@ -223,7 +224,8 @@ public:
   }
 
   /* Get a full annotated query string with bound values replaced for debugging (only for named bindings) */
-  QString getFullQueryString() const;
+  // not in use anywhere (afais), implementation detail requirement not available in core and too exhausting to code now
+  //QString getFullQueryString() const;
 
   void bindValues(const QVector<std::pair<QString, QVariant> >& bindValues);
   void bindValues(const QVector<std::pair<int, QVariant> >& bindValues);
@@ -237,8 +239,8 @@ private:
 
   QSqlQuery query;
   QString queryString;
-  SqlDatabase *db = nullptr;
-  QString boundValuesAsString() const;
+  SqlDatabase* db = nullptr;
+  //QString boundValuesAsString() const;
 
 };
 

--- a/src/sql/sqlrecord.cpp
+++ b/src/sql/sqlrecord.cpp
@@ -278,7 +278,7 @@ QDebug operator<<(QDebug out, const atools::sql::SqlRecord& record)
 
   out << "SqlRecord[";
   for(int i = 0; i < record.count(); ++i)
-    out << record.sqlRecord.fieldName(i) << record.sqlRecord.value(i) << endl;
+    out << record.sqlRecord.fieldName(i) << record.sqlRecord.value(i) << Qt::endl;
   out << "]";
 
   return out;

--- a/src/sql/sqlrecord.h
+++ b/src/sql/sqlrecord.h
@@ -21,6 +21,7 @@
 #include <QSqlRecord>
 #include <QVariant>
 #include <QVector>
+#include <QSqlField>
 
 class QSqlRecord;
 
@@ -30,7 +31,7 @@ namespace sql {
 class SqlQuery;
 
 /*
- * Wrapper around SqlRecord that adds additional error checking and exceptions to
+ * Wrapper around QSqlRecord that adds additional error checking and exceptions to
  * avoid manual error checking. In case of error or invalid connections SqlException
  * is thrown.
  * Exception is also thrown if a value() receive an invalid
@@ -181,6 +182,11 @@ public:
   QSqlRecord& getSqlRecord()
   {
     return sqlRecord;
+  }
+
+  QSqlField field(int index) const
+  {
+    return sqlRecord.field(index);
   }
 
   void appendField(const QString& fieldName, QVariant::Type type);

--- a/src/sql/sqlscript.cpp
+++ b/src/sql/sqlscript.cpp
@@ -127,7 +127,7 @@ void SqlScript::parseSqlScript(QTextStream& script, QList<ScriptCmd>& statements
 
   while(!script.atEnd())
   {
-    QChar lastChar = 0;
+    QChar lastChar = '\0';
 
     line = script.readLine();
 
@@ -206,7 +206,7 @@ void SqlScript::parseSqlScript(QTextStream& script, QList<ScriptCmd>& statements
             isSingleString = false;
             isDoubleString = false;
             isBlockComment = false;
-            lastChar = 0;
+            lastChar = '\0';
           }
         }
         else

--- a/src/sql/sqlutil.h
+++ b/src/sql/sqlutil.h
@@ -129,8 +129,9 @@ private:
   QStringList buildTableList(const QStringList& tables);
   QStringList buildResultList(atools::sql::SqlQuery& query);
 
-  static void copyRowValuesInternal(const atools::sql::SqlQuery& from, atools::sql::SqlQuery& to,
-                                    const atools::sql::SqlRecord& fromRec, const QMap<QString, QVariant>& bound);
+  static void prepareRowValuesInternal(const atools::sql::SqlQuery& from, atools::sql::SqlQuery& to);
+
+  static bool returnTrue(SqlQuery& from, SqlQuery& to);
 
 };
 

--- a/src/templateengine/templateloader.cpp
+++ b/src/templateengine/templateloader.cpp
@@ -9,6 +9,7 @@
 #include <QStringList>
 #include <QDir>
 #include <QSet>
+#include <QRegularExpression>
 
 using namespace stefanfrings;
 
@@ -61,12 +62,12 @@ QString TemplateLoader::tryFile(QString localizedName)
 Template TemplateLoader::getTemplate(QString templateName, QString locales)
 {
   QSet<QString> tried;   // used to suppress duplicate attempts
-  QStringList locs = locales.split(',', QString::SkipEmptyParts);
+  QStringList locs = locales.split(',', Qt::SkipEmptyParts);
 
   // Search for exact match
   foreach(QString loc, locs)
   {
-    loc.replace(QRegExp(";.*"), "");
+    loc.replace(QRegularExpression(";.*"), "");
     loc.replace('-', '_');
     QString localizedName = templateName + "-" + loc.trimmed();
     if(!tried.contains(localizedName))
@@ -83,7 +84,7 @@ Template TemplateLoader::getTemplate(QString templateName, QString locales)
   // Search for correct language but any country
   foreach(QString loc, locs)
   {
-    loc.replace(QRegExp("[;_-].*"), "");
+    loc.replace(QRegularExpression("[;_-].*"), "");
     QString localizedName = templateName + "-" + loc.trimmed();
     if(!tried.contains(localizedName))
     {

--- a/src/track/trackdownloader.cpp
+++ b/src/track/trackdownloader.cpp
@@ -220,7 +220,7 @@ void TrackDownloader::setUrl(TrackType type, const QString& url, const QStringLi
 
 void TrackDownloader::startAllDownloads()
 {
-  for(HttpDownloader *downloader : downloaders)
+  for(HttpDownloader *downloader : qAsConst(downloaders))
     downloader->startDownload();
 }
 
@@ -231,7 +231,7 @@ void TrackDownloader::startDownload(TrackType type)
 
 void TrackDownloader::cancelAllDownloads()
 {
-  for(HttpDownloader *downloader : downloaders)
+  for(HttpDownloader *downloader : qAsConst(downloaders))
     downloader->cancelDownload();
 }
 
@@ -242,14 +242,14 @@ const atools::track::TrackVectorType& TrackDownloader::getTracks(TrackType type)
 
 void TrackDownloader::clearTracks()
 {
-  for(atools::track::TrackType key : trackList.keys())
-    trackList[key].clear();
+  for(auto key : qAsConst(trackList))
+    key.clear();
 }
 
 bool TrackDownloader::hasAnyTracks()
 {
   int num = 0;
-  for(const TrackVectorType& tracks : trackList)
+  for(const TrackVectorType& tracks : qAsConst(trackList))
     num += tracks.size();
   return num > 0;
 }
@@ -262,14 +262,14 @@ bool TrackDownloader::hasTracks(TrackType type)
 int TrackDownloader::removeInvalid()
 {
   int num = 0;
-  for(atools::track::TrackType key : trackList.keys())
-    num += TrackReader::removeInvalid(trackList[key]);
+  for(auto key : qAsConst(trackList))
+    num += TrackReader::removeInvalid(key);
   return num;
 }
 
 void TrackDownloader::setIgnoreSslErrors(bool value)
 {
-  for(HttpDownloader *downloader : downloaders)
+  for(HttpDownloader *downloader : qAsConst(downloaders))
     downloader->setIgnoreSslErrors(value);
 }
 

--- a/src/track/trackdownloader.h
+++ b/src/track/trackdownloader.h
@@ -21,6 +21,8 @@
 #include "track/tracktypes.h"
 
 #include <QObject>
+#include <QHash>
+#include <QList>
 
 namespace atools {
 namespace util {

--- a/src/track/trackreader.h
+++ b/src/track/trackreader.h
@@ -22,7 +22,6 @@
 
 #include <QApplication>
 
-class QStringList;
 class QTextStream;
 
 namespace atools {

--- a/src/util/filesystemwatcher.cpp
+++ b/src/util/filesystemwatcher.cpp
@@ -69,7 +69,7 @@ void FileSystemWatcher::pathOrFileChanged()
           qDebug() << Q_FUNC_INFO << "File" << filename
                    << "exists" << fileinfo.exists()
                    << "size" << fileinfo.size()
-                   << "last modified" << fileinfo.lastModified().toString(Qt::DefaultLocaleShortDate);
+                   << "last modified" << QLocale(fileinfo.lastModified().toString()).dateTimeFormat(QLocale::ShortFormat);
 
         // File exists - first call or older than two minutes or file differs
         if(!fileTimestampLastRead.isValid() ||

--- a/src/util/properties.cpp
+++ b/src/util/properties.cpp
@@ -36,7 +36,7 @@ Properties::Properties(const QHash<QString, QString>& other)
 void Properties::write(QTextStream& stream) const
 {
   for(const QString& name : keys())
-    stream << name << "=" << value(name) << endl;
+    stream << name << "=" << value(name) << Qt::endl;
 }
 
 void Properties::read(QTextStream& stream)

--- a/src/util/updatecheck.cpp
+++ b/src/util/updatecheck.cpp
@@ -26,11 +26,11 @@ namespace util {
 
 // Split the download links for used OS
 #if defined(Q_OS_WIN32)
-static const QLatin1Literal DOWNLOAD_KEY("downloadwin");
+static const QLatin1String DOWNLOAD_KEY("downloadwin");
 #elif defined(Q_OS_MACOS)
-static const QLatin1Literal DOWNLOAD_KEY("downloadmac");
+static const QLatin1String DOWNLOAD_KEY("downloadmac");
 #else
-static const QLatin1Literal DOWNLOAD_KEY("downloadlinux");
+static const QLatin1String DOWNLOAD_KEY("downloadlinux");
 #endif
 
 UpdateCheck::UpdateCheck(bool forceDebug)
@@ -69,8 +69,7 @@ void UpdateCheck::checkForUpdates(const QString& versionsAlreadChecked, bool not
   {
     // Connect signals for this request
     connect(reply, &QNetworkReply::finished, this, &UpdateCheck::httpFinished);
-    connect(reply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error),
-            this, &UpdateCheck::httpError);
+    connect(reply, &QNetworkReply::errorOccurred, this, &UpdateCheck::httpError);        // TODO: verify deleted not allowed static cast to void* return type is fine
   }
 }
 
@@ -182,7 +181,7 @@ void UpdateCheck::readUpdateMessage(UpdateList& updates, QString update)
         }
         else if(key.startsWith("download"))
         {
-          if(key == DOWNLOAD_KEY || key == "download")
+          if(key == QString(DOWNLOAD_KEY) || key == "download")
             // OS specific or general download
             map[currentChannel].download = value;
           changelogContinuation = false;
@@ -229,8 +228,7 @@ void UpdateCheck::endRequest()
   if(reply != nullptr)
   {
     disconnect(reply, &QNetworkReply::finished, this, &UpdateCheck::httpFinished);
-    disconnect(reply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error),
-               this, &UpdateCheck::httpError);
+    disconnect(reply, &QNetworkReply::errorOccurred, this, &UpdateCheck::httpError);          // TODO: see connect
     reply->abort();
     reply->deleteLater();
     reply = nullptr;

--- a/src/util/xmlstream.cpp
+++ b/src/util/xmlstream.cpp
@@ -30,25 +30,25 @@ namespace util {
 XmlStream::XmlStream(QIODevice *device, const QString& filenameParam)
   : filename(filenameParam)
 {
-  QTextCodec *codec = atools::codecForFile(*device);
+  /* QTextCodec *codec = atools::codecForFile(*device);     // TODO: evaluate; no new API found to connect Codec to Stream
 
   if(codec != nullptr)
   {
     // Load the file into a text file to avoid BOM / xml encoding mismatches
     qDebug() << "Encoding" << codec->name();
     QTextStream stream(device);
-    stream.setCodec(codec);
+    // stream.setCodec(codec);
     QString str = stream.readAll();
 
     // The reader ignores the XML encoding header when reading from a string
     reader = new QXmlStreamReader(str);
   }
   else
-  {
+  {*/
     // Let the stream reader detect the encoding in the PI
     qDebug() << "No UTF Encoding found";
     reader = new QXmlStreamReader(device);
-  }
+  /*}*/
 }
 
 XmlStream::XmlStream(const QByteArray& data, const QString& filenameParam)

--- a/src/win/activationcontext.cpp
+++ b/src/win/activationcontext.cpp
@@ -29,8 +29,13 @@ extern "C" {
 }
 #endif
 
+#if ! _MSC_VER || __INTEL_COMPILER                      // intel compiler defines _MSC_VER, didn't check whether it supports GCC
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#else
+#pragma warning(push)
+#pragma warning(disable:4100)
+#endif
 
 namespace atools {
 namespace win {
@@ -262,3 +267,8 @@ void *ActivationContext::getProcAddress(QString libraryName, const QString& proc
 
 } // namespace win
 } // namespace atools
+
+
+#if _MSC_VER && ! __INTEL_COMPILER
+#pragma warning(pop)
+#endif

--- a/src/wmm/GeomagnetismHeader.h
+++ b/src/wmm/GeomagnetismHeader.h
@@ -346,7 +346,7 @@ void MAG_PrintUserData(MAGtype_GeoMagneticElements GeomagElements,
                        MAGtype_MagneticModel *MagneticModel,
                        MAGtype_Geoid *Geoid);
 
-int MAG_ValidateDMSstring(char *input, int min, int max, char *Error);
+int MAG_ValidateDMSstring(char *input, double min, double max, char *Error);
 
 int MAG_Warnings(int control, double value, MAGtype_MagneticModel *MagneticModel);
 

--- a/src/wmm/GeomagnetismLibrary.c
+++ b/src/wmm/GeomagnetismLibrary.c
@@ -1,3 +1,5 @@
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -1443,7 +1445,7 @@ void MAG_PrintUserData(MAGtype_GeoMagneticElements GeomagElements, MAGtype_Coord
 
 } /*MAG_PrintUserData*/
 
-int MAG_ValidateDMSstring(char *input, int min, int max, char *Error)
+int MAG_ValidateDMSstring(char *input, double min, double max, char *Error)
 {
   /* Validates a latitude DMS string, and returns 1 for a success and returns 0 for a failure.
    *  It copies an error message to the Error string in the event of a failure.
@@ -1491,7 +1493,7 @@ int MAG_ValidateDMSstring(char *input, int min, int max, char *Error)
   }
   if(degree > max || degree < min)
   {
-    sprintf(Error, "\nError: Degree input is outside legal range\n The legal range is from %d to %d\n", min, max);
+    sprintf(Error, "\nError: Degree input is outside legal range\n The legal range is from %f to %f\n", min, max);
     return FALSE;
   }
   if(degree == max || degree == min)
@@ -2129,7 +2131,8 @@ void MAG_PrintEMMFormat(char *filename, char *filenameSV, MAGtype_MagneticModel 
 
 void MAG_PrintSHDFFormat(char *filename, MAGtype_MagneticModel *(*MagneticModel)[], int epochs)
 {
-  int i, n, m, index, epochRange;
+  int i, n, m, index;
+  double epochRange;
   FILE *SHDF_file;
   SHDF_file = fopen(filename, "w");
   /*lines = (int)(UFM_DEGREE / 2.0 * (UFM_DEGREE + 3));*/
@@ -2146,7 +2149,7 @@ void MAG_PrintSHDFFormat(char *filename, MAGtype_MagneticModel *(*MagneticModel)
     fprintf(SHDF_file, "%%ReleaseDate: Some Number\n");
     fprintf(SHDF_file, "%%DataCutOFF: Some Other Number\n");
     fprintf(SHDF_file, "%%ModelStartYear: %d\n", (int)(*MagneticModel)[i]->epoch);
-    fprintf(SHDF_file, "%%ModelEndYear: %d\n", (int)(*MagneticModel)[i]->epoch + epochRange);
+    fprintf(SHDF_file, "%%ModelEndYear: %f\n", (int)(*MagneticModel)[i]->epoch + epochRange);
     fprintf(SHDF_file, "%%Epoch: %.0f\n", (*MagneticModel)[i]->epoch);
     fprintf(SHDF_file, "%%IntStaticDeg: %d\n", (*MagneticModel)[i]->nMax);
     fprintf(SHDF_file, "%%IntSecVarDeg: %d\n", (*MagneticModel)[i]->nMaxSecVar);
@@ -2157,8 +2160,8 @@ void MAG_PrintSHDFFormat(char *filename, MAGtype_MagneticModel *(*MagneticModel)
     fprintf(SHDF_file, "# To synthesize the field for a given date:\n");
     fprintf(SHDF_file, "# Use the sub-model of the epoch corresponding to each date\n");
     fprintf(SHDF_file, "#\n#\n#\n#\n# I/E, n, m, Gnm, Hnm, SV-Gnm, SV-Hnm\n#\n");
-    n = 1;
-    m = 0;
+    //n = 1;
+    //m = 0;
     for(n = 1; n <= (*MagneticModel)[i]->nMax; n++)
     {
       for(m = 0; m <= n; m++)
@@ -3337,7 +3340,7 @@ int MAG_YearToDate(MAGtype_Date *CalendarDate)
   if((CalendarDate->Year % 4 == 0 && CalendarDate->Year % 100 != 0) || CalendarDate->Year % 400 == 0)
     ExtraDay = 1;
 
-  DayOfTheYear = floor((CalendarDate->DecimalYear - (double)CalendarDate->Year) * (365.0 + (double)ExtraDay) + 0.5) + 1;
+  DayOfTheYear = (int)floor((CalendarDate->DecimalYear - (double)CalendarDate->Year) * (365.0 + (double)ExtraDay) + 0.5) + 1;
   /*The above floor is used for rounding, this only works for positive integers*/
 
   MonthDays[0] = 0;

--- a/src/zip/gzip.h
+++ b/src/zip/gzip.h
@@ -20,7 +20,7 @@
 #ifndef ATOOLS_ZIP_GZIP_H
 #define ATOOLS_ZIP_GZIP_H
 
-#include <zlib.h>
+#include "QtZlib/zlib.h"
 
 class QByteArray;
 class QString;


### PR DESCRIPTION
80 %  type-based:
 <Qxxx> added,
 Qt:: added,
 Qyyy::ENUM changed,
 QVector overlaods deleted (is alias of QList),
 QzzzLiteral are now simply QzzzString,
 QFileInfo constructor around paths,
 comparison with letters: 'A' (not "A"),
 some new methods ("secsSinceEpoch" instead of "time_t", "setEncoding" instead of "setCodec",
 ...
some explicit casts (5%)
some msvc #pragmas (5%)
logic adjusment File Dialog (3%),
logic correction SQL (7%) (prepared statement placeholders have no API to get them!)