### PR TITLE
Fix bug in which Little Navmap would only read and display a single transition from addon SIDs and STARs, despite these procedures actually having more than 1 transition.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/../../../../:\Desenvolvimento\atools\.idea/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/atools.iml
+++ b/.idea/atools.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/atools.iml" filepath="$PROJECT_DIR$/.idea/atools.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/fs/bgl/ap/sidstar.cpp
+++ b/src/fs/bgl/ap/sidstar.cpp
@@ -135,7 +135,17 @@ SidStar::SidStar(const NavDatabaseOptions *options, BinaryStream *bs)
           bs->skip(1); /* unknown byte, usually zero */
           if(rec::ENROUTE_TRANSITIONS_MSFS_116 == recType)
           {
-            name = bs->readString(8, atools::io::UTF8);
+              /*
+               * Note: The name field of the EnrouteTransitions record is now unused by
+               * the current version of MSFS 2020 SDK, and hence all of its bytes are left NULL.
+               * All transitions are named after their first (STAR) or last (SID) leg.
+               *
+               * In fact, a XML file containing <EnrouteTransitions name="SAVLA"> is not compiled
+               * compiled by the SDK anymore. The SDK registers it as an invalid field error.
+               *
+               * Therefore, these 8 bytes can be skipped.
+               */
+              (void)bs->readString(8, atools::io::UTF8);
           }
           /* Create a container for the transition legs */
           QList<ApproachLeg> legs;
@@ -145,20 +155,18 @@ SidStar::SidStar(const NavDatabaseOptions *options, BinaryStream *bs)
           for(int i = 0; i < numLegs; i++)
             legs.append(ApproachLeg(bs, legRec.getId<rec::ApprRecordType>()));
 
-          if(rec::ENROUTE_TRANSITIONS_MSFS_116 != recType)
+          /* Get the ident (key) of the transition. Must always be done this way. */
+          if(rec::MSFS_SID == id)
           {
-            /* Now to figure out the "key" for this transition... */
-            if(rec::MSFS_SID == id)
-            {
-              /* For SID, the transition ident is the LAST leg's fix. */
-              name = legs.constLast().getFixIdent();
-            }
-            else if(rec::MSFS_STAR == id)
-            {
-              /* For STAR, the transition ident is the FIRST leg's fix */
-              name = legs.constFirst().getFixIdent();
-            }
+            /* For SID, the transition ident is the LAST leg's fix. */
+            name = legs.constLast().getFixIdent();
           }
+          else if(rec::MSFS_STAR == id)
+          {
+            /* For STAR, the transition ident is the FIRST leg's fix */
+            name = legs.constFirst().getFixIdent();
+          }
+
           if(!legs.isEmpty())
             enrouteTransitions.insert(name, legs);
           else


### PR DESCRIPTION
Hi Alex. I am a user of Little Navmap for a while now, and now I would like to make my small contribution to this great project.

While adding some missing Procedures in Queenstown Airport, New Zealand, I noticed that Little Navmap would only show a **single transition** of my custom SIDs and STARs, despite them having 2 or 3 different transitions. The issue seems to be due to a change in the MSFS 2020 BGL file format.

Currently, the 8-byte "name" field of the EnrouteTransitions record is now unused by MSFS 2020 SDK. In fact, MSFS 2020 SDK does not even compile an XML that contains a "name" field inside `<EnrouteTransitions>`. Therefore, all bytes reserved for the transition name are left NULL.

However, `sidstar.cpp` does not take that fact into account. Every time Little Navmap reads a BGL created by the current SDK version, the `SidStar` constructor would always register the ident of all SID/STAR transitions as the **same** 8-byte string filled with null characters. Therefore, each transition inserted into the `enrouteTransitions` list would always replace the previous one, as the same key would be used.

As a result, any custom created SID/STAR and compiled using the current version of the MSFS SDK would appear in Little Navmap as having a single transition: the last one read by atools. I have attached my own addon I have been working on, which is able to reproduce this bug. For example, compare IPNO3A and IPNO3B SIDs with their respective charts.

Addon procedures: [gfrd-airport-nzqn-queenstown.zip](https://github.com/albar965/atools/files/8748258/gfrd-airport-nzqn-queenstown.zip)
Actual charts: [SID RNP - IPNOR 3A & 3B - NZQN_62.05_62.06.pdf](https://github.com/albar965/atools/files/8748259/SID.RNP.-.IPNOR.3A.3B.-.NZQN_62.05_62.06.pdf)

This is my suggestion to fix this bug:
- In `sidstar.cpp`, skip the 8-byte "name" field of the EnrouteTransitions record (when it is a `ENROUTE_TRANSITIONS_MSFS_116` type);
- Always get the ident as the first (STAR) or last (SID) leg of the procedure.