### PR TITLE
Improve Flightgear flightplan IO

### DIFF
--- a/src/fs/pln/flightplanio.cpp
+++ b/src/fs/pln/flightplanio.cpp
@@ -1474,7 +1474,9 @@ void FlightplanIO::loadFlightGear(atools::fs::pln::Flightplan& plan, const QStri
 
             maxAlt = std::max(maxAlt, altitude);
 
-            entry.setPosition(Pos(wplon.toFloat(), wplat.toFloat(), altitude));
+            Pos position(wplon, wplat, altitude);
+            if (position.isValid())
+              entry.setPosition(position);
 
             if(wptype == "runway")
             {

--- a/src/fs/pln/flightplanio.cpp
+++ b/src/fs/pln/flightplanio.cpp
@@ -2151,7 +2151,12 @@ void FlightplanIO::saveFlightGear(const Flightplan& plan, const QString& filenam
       }
 
       if(!hasProcedure)
-        writePropertyStr(writer, "type", "navaid");
+      {
+        if (entry.getWaypointType() == entry::USER)
+          writePropertyStr(writer, "type", "basic");
+        else
+          writePropertyStr(writer, "type", "navaid");
+      }
 
       if(i > 0 && i < plan.entries.size() - 1)
       {

--- a/src/fs/pln/flightplanio.cpp
+++ b/src/fs/pln/flightplanio.cpp
@@ -1491,6 +1491,17 @@ void FlightplanIO::loadFlightGear(atools::fs::pln::Flightplan& plan, const QStri
               entry.setIdent(wpident);
               plan.getEntries().append(entry);
             }
+            else if(wptype == "basic")
+            {
+              // Basic waypoint: only lat/lon tags are meaningfull
+              // (might be a custom waypoint, or navaid missing from database)
+              if(position.isValid())
+              {
+                entry.setIdent(wpident);
+                entry.setWaypointType(entry::USER);
+                plan.getEntries().append(entry);
+              }
+            }
           }
           else
             reader.skipCurrentElement();


### PR DESCRIPTION
This is a series of small improvements to Flightgear XML flightplan files import and export.

Commit 1 allows loading waypoints which are missing coordinates. (This is valid in fgfp files, and in particular this is how Flightgear exports runways.) Previously, such waypoints would end up with coordinates 0,0.

Commits 2 and 3 handle waypoints marked with `<type>basic</type>` when loading and exporting respectively. Type "basic" has a role somewhat comparable LNM "user" waypoints, although Flightgear also uses it as fallback for unknown navaids, see commit messages for details.

The following fgfp file (exported from Flightgear) illustrate the changes.
Prior to the changes, departure and destination end up at coordinates 0,0, and waypoint 1 is discarded.
With the modifications, all four are loaded correctly, and waypoint 1 becomes a user waypoint.
```xml
<?xml version="1.0"?>

<PropertyList>
  <version type="int">2</version>
  <departure>
    <airport type="string">LFMT</airport>
    <runway type="string">12L</runway>
  </departure>
  <destination>
    <airport type="string">LFML</airport>
    <runway type="string">13L</runway>
  </destination>
  <route>
    <wp>
      <type type="string">runway</type>
      <departure type="bool">true</departure>
      <ident type="string">12L</ident>
      <icao type="string">LFMT</icao>
    </wp>
    <wp n="1">
      <type type="string">basic</type>
      <ident type="string">CUSTOM1</ident>
      <lon type="double">4.31158733</lon>
      <lat type="double">43.36803818</lat>
    </wp>
    <wp n="2">
      <type type="string">navaid</type>
      <ident type="string">SALIN</ident>
      <lon type="double">4.730278</lon>
      <lat type="double">43.282778</lat>
    </wp>
    <wp n="3">
      <type type="string">runway</type>
      <approach type="bool">true</approach>
      <ident type="string">13L</ident>
      <icao type="string">LFML</icao>
    </wp>
  </route>
</PropertyList>
```